### PR TITLE
added roll template info for spells tab/section...

### DIFF
--- a/Pathfinder-Neceros-roll-template/pathfinder-neceros-roll-template.html
+++ b/Pathfinder-Neceros-roll-template/pathfinder-neceros-roll-template.html
@@ -1,5 +1,5 @@
 <div style="display:none;">
-<b style="color:red;font-size:150%;">Attention: </b>
+    <b style="color:red;font-size:150%;">Attention: </b>
 </div>
 <div class="sheet-table sheet-header">
     <div class="sheet-table-row">
@@ -53,9 +53,9 @@
 				<span class="sheet-table-header">Drain</span>
 			</div>
 			<div class="sheet-table-row">
-				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|STR-Check}" type="roll" name="roll_STR-Check" value="@{character_name}'s STR Check: [[1d20 + @{STR-mod}]]">STR</button></span>
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|STR-Check}" type="roll" name="roll_STR-Check" value="@{character_name}'s STR Check: [[1d20 + @{STR-mod} - @{condition-fear} - @{condition-sickened}]]">STR</button></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR}" type="number" name="attr_STR" value="(@{STR-base} + @{STR-enhance} + @{STR-misc} + @{STR-drain})" disabled></span>
-				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-mod}" type="number" name="attr_STR-mod" value="((floor(@{STR}/2)-5) + floor(@{STR-temp}/2) - (floor(abs(@{STR-damage})/2)) - (floor(abs(@{STR-penalty})/2)))" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-mod}" type="number" name="attr_STR-mod" value="((floor(@{STR}/2)-5) + floor(@{STR-temp}/2) - (floor(abs(@{STR-damage})/2)) - (floor(abs(@{STR-penalty})/2)) - @{condition-fatigued})" disabled></span>
 				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-base}" type="number" name="attr_STR-base" value="10"></span>
 				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
@@ -68,9 +68,9 @@
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-drain}" type="number" name="attr_STR-drain" value="0" max="0"></span>
 			</div>
 			<div class="sheet-table-row">
-				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|DEX-Check}" type="roll" name="roll_DEX-Check" value="@{character_name}'s DEX Check: [[1d20 + @{DEX-mod}]]">DEX</button></span>
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|DEX-Check}" type="roll" name="roll_DEX-Check" value="@{character_name}'s DEX Check: [[1d20 + @{DEX-mod} - @{condition-fear} - @{condition-sickened}]]">DEX</button></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX}" type="number" name="attr_DEX" value="(@{DEX-base} + @{DEX-enhance} + @{DEX-misc} + @{DEX-drain})" disabled></span>
-				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-mod}" type="number" name="attr_DEX-mod" value="((floor(@{DEX}/2)-5) + floor(@{DEX-temp}/2) - (floor(abs(@{DEX-damage})/2)) - (floor(abs(@{DEX-penalty})/2)))" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-mod}" type="number" name="attr_DEX-mod" value="((floor(@{DEX}/2)-5) + floor(@{DEX-temp}/2) - (floor(abs(@{DEX-damage})/2)) - (floor(abs(@{DEX-penalty})/2)) - @{condition-entangled} - @{condition-grappled} - @{condition-fatigued})" disabled></span>
 				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-base}" type="number" name="attr_DEX-base" value="10"></span>
 				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
@@ -83,7 +83,7 @@
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-drain}" type="number" name="attr_DEX-drain" value="0" max="0"></span>
 			</div>
 			<div class="sheet-table-row">
-				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|CON-Check}" type="roll" name="roll_CON-Check" value="@{character_name}'s CON Check: [[1d20 + @{CON-mod}]]">CON</button></span>
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|CON-Check}" type="roll" name="roll_CON-Check" value="@{character_name}'s CON Check: [[1d20 + @{CON-mod} - @{condition-fear} - @{condition-sickened}]]">CON</button></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON}" type="number" name="attr_CON" value="(@{CON-base} + @{CON-enhance} + @{CON-misc} + @{CON-drain})" disabled></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-mod}" type="number" name="attr_CON-mod" value="((floor(@{CON}/2)-5) + floor(@{CON-temp}/2) - (floor(abs(@{CON-damage})/2)) - (floor(abs(@{CON-penalty})/2)))" disabled></span>
 				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
@@ -98,7 +98,7 @@
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-drain}" type="number" name="attr_CON-drain" value="0" max="0"></span>
 			</div>
 			<div class="sheet-table-row">
-				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|INT-Check}" type="roll" name="roll_INT-Check" value="@{character_name}'s INT Check: [[1d20 + @{INT-mod}]]">INT</button></span>
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|INT-Check}" type="roll" name="roll_INT-Check" value="@{character_name}'s INT Check: [[1d20 + @{INT-mod} - @{condition-fear} - @{condition-sickened}]]">INT</button></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT}" type="number" name="attr_INT" value="(@{INT-base} + @{INT-enhance} + @{INT-misc} + @{INT-drain})" disabled></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT-mod}" type="number" name="attr_INT-mod" value="((floor(@{INT}/2)-5) + floor(@{INT-temp}/2) - (floor(abs(@{INT-damage})/2)) - (floor(abs(@{INT-penalty})/2)))" disabled></span>
 				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
@@ -113,7 +113,7 @@
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT-drain}" type="number" name="attr_INT-drain" value="0" max="0"></span>
 			</div>
 			<div class="sheet-table-row">
-				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|WIS-Check}" type="roll" name="roll_WIS-Check" value="@{character_name}'s WIS Check: [[1d20 + @{WIS-mod}]]">WIS</button></span>
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|WIS-Check}" type="roll" name="roll_WIS-Check" value="@{character_name}'s WIS Check: [[1d20 + @{WIS-mod} - @{condition-fear} - @{condition-sickened}]]">WIS</button></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS}" type="number" name="attr_WIS" value="(@{WIS-base} + @{WIS-enhance} + @{WIS-misc} + @{WIS-drain})" disabled></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-mod}" type="number" name="attr_WIS-mod" value="((floor(@{WIS}/2)-5) + floor(@{WIS-temp}/2) - (floor(abs(@{WIS-damage})/2)) - (floor(abs(@{WIS-penalty})/2)))" disabled></span>
 				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
@@ -128,7 +128,7 @@
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-drain}" type="number" name="attr_WIS-drain" value="0" max="0"></span>
 			</div>
 			<div class="sheet-table-row">
-				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|CHA-Check}" type="roll" name="roll_CHA-Check" value="@{character_name}'s CHA Check: [[1d20 + @{CHA-mod}]]">CHA</button></span>
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|CHA-Check}" type="roll" name="roll_CHA-Check" value="@{character_name}'s CHA Check: [[1d20 + @{CHA-mod} - @{condition-fear} - @{condition-sickened}]]">CHA</button></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA}" type="number" name="attr_CHA" value="(@{CHA-base} + @{CHA-enhance} + @{CHA-misc} + @{CHA-drain})" disabled></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-mod}" type="number" name="attr_CHA-mod" value="((floor(@{CHA}/2)-5) + floor(@{CHA-temp}/2) - (floor(abs(@{CHA-damage})/2)) - (floor(abs(@{CHA-penalty})/2)))" disabled></span>
 				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
@@ -141,6 +141,35 @@
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-damage}" type="number" name="attr_CHA-damage" value="0" max="0"></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-penalty}" type="number" name="attr_CHA-penalty" value="0" max="0"></span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-drain}" type="number" name="attr_CHA-drain" value="0" max="0"></span>
+			</div>
+		</div>
+		<br>
+	</div>
+	<div>
+		<b>Conditions&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{conditions-show}" name="attr_conditions-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+            <span class="sheet-table-name">Conditions</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-left"><input type="checkbox" title="@{condition-Blinded}" name="attr_condition-Blinded" value="2"/><b title="-2 penalty to Armor Class">Blinded</b></span>
+				<span class="sheet-table-data sheet-left"><input type="checkbox" title="@{condition-Cowering}" name="attr_condition-Cowering" value="2"/><b title="-2 penalty to Armor Class">Cowering</b></span>
+				<span class="sheet-table-data sheet-left"><input type="checkbox" title="@{condition-Dazzled}" name="attr_condition-Dazzled" value="1"/><b title="-1 penalty on attack rolls">Dazzled</b></span>
+				<span class="sheet-table-data sheet-left"><input type="checkbox" title="@{condition-Deafened}" name="attr_condition-Deafened" value="4"/><b title="-4 penalty on initiative rolls">Deafened</b></span>
+				<span class="sheet-table-data sheet-left"><input type="checkbox" title="@{condition-Entangled}" name="attr_condition-Entangled" value="2"/><b title="–2 penalty on all attack rolls and a –4 penalty to Dexterity">Entangled</b></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-left"><input type="checkbox" title="@{condition-Fear}" name="attr_condition-Fear" value="2"/><b title="Shaken/Frightened/Panicked: -2 penalty on attack rolls, saving throws, skill checks, and ability checks">Fear</b></span>
+				<span class="sheet-table-data sheet-left"><input type="checkbox" title="@{condition-Grappled}" name="attr_condition-Grappled" value="2"/><b title="–2 penalty on all attack rolls and a –4 penalty to Dexterity">Grappled</b></span>
+				<span class="sheet-table-data sheet-left"><input type="checkbox" title="@{condition-Invisible}" name="attr_condition-Invisible" value="2"/><b title="+2 bonus on attack rolls">Invisible</b></span>
+				<span class="sheet-table-data sheet-left"><input type="checkbox" title="@{condition-Prone}" name="attr_condition-Prone" value="4"/><b title="–4 penalty on melee attack rolls">Prone</b></span>
+				<span class="sheet-table-data sheet-left"><input type="checkbox" title="@{condition-Pinned}" name="attr_condition-Pinned" value="4"/><b title="Additional –4 penalty to Armor Class">Pinned</b></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-left"><input type="checkbox" title="@{condition-Sickened}" name="attr_condition-Sickened" value="2"/><b title="–2 penalty on all attack rolls, weapon damage rolls, saving throws, skill checks, and ability checks">Sickened</b></span>
+				<span class="sheet-table-data sheet-left"><input type="checkbox" title="@{condition-Stunned}" name="attr_condition-Stunned" value="2"/><b title="-2 penalty to Armor Class">Stunned</b></span>
+				<span class="sheet-table-data sheet-left"><input type="radio" title="@{condition-Fatigued}" name="attr_condition-Fatigued" value="1"/><b title="–2 penalty to Strength and Dexterity">Fatigued</b></span>
+				<span class="sheet-table-data sheet-left"><input type="radio" title="@{condition-Fatigued}" name="attr_condition-Fatigued" value="3"/><b title="–6 penalty to Strength and Dexterity">Exhausted</b></span>
+				<span class="sheet-table-data sheet-left"><input type="radio" title="@{condition-Fatigued}" name="attr_condition-Fatigued" value="0" checked/><b>Neither</b></span>
 			</div>
 		</div>
 		<br>
@@ -189,7 +218,7 @@
 						</div>
 						<div class="sheet-table-row">
 							<span class="sheet-table-data sheet-center" style="width:5%;"><button title="%{selected|Roll-for-initiative}" type="roll" name="roll_Roll-for-initiative" value="@{character_name}'s Initiative result: [[((1d20 + @{init}) + (0.01 * @{init})) &amp;{tracker}]]"></button></span>
-							<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" title="@{init}" name="attr_init" value="(@{DEX-mod} + @{init-misc} + @{init-trait})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" title="@{init}" name="attr_init" value="(@{DEX-mod} + @{init-misc} + @{init-trait} - @{condition-deafened})" disabled></span>
 							<span class="sheet-table-data sheet-center">=</span>
 							<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" title="@{DEX-mod}" name="attr_init-DEX" value="@{DEX-mod}" disabled></span>
 							<span class="sheet-table-data sheet-center">+</span>
@@ -498,7 +527,7 @@
 			</div>
 			<div class="sheet-table-row">
 				<span class="sheet-table-row-name">AC</span>
-				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC}" type="number" name="attr_AC" value="(10 + @{AC-armor} + @{AC-shield} + @{AC-DEX} + @{size} + @{AC-dodge} + @{AC-natural} + @{AC-deflect} + @{AC-misc} + @{AC-temp} + @{AC-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC}" type="number" name="attr_AC" value="(10 + @{AC-armor} + @{AC-shield} + @{AC-DEX} + @{size} + @{AC-dodge} + @{AC-natural} + @{AC-deflect} + @{AC-misc} + @{AC-temp} + @{AC-penalty} - @{condition-blinded} - @{condition-cowering} - @{condition-stunned} - @{condition-pinned})" disabled></span>
 				<span class="sheet-table-data sheet-center" style="width:48px;">= 10 +</span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{armor-acbonus}" type="number" name="attr_AC-armor" value="(@{armor-acbonus} * @{armor-equipped})" disabled></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -522,7 +551,7 @@
 			</div>
 			<div class="sheet-table-row">
 				<span class="sheet-table-row-name" style="width:90px;">Touch</span>
-				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Touch}" type="number" name="attr_Touch" value="(10 + @{AC-DEX} + @{size} + @{AC-dodge} + @{AC-deflect} + @{AC-misc} + @{AC-temp} + @{AC-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Touch}" type="number" name="attr_Touch" value="(10 + @{AC-DEX} + @{size} + @{AC-dodge} + @{AC-deflect} + @{AC-misc} + @{AC-temp} + @{AC-penalty} - @{condition-blinded} - @{condition-cowering} - @{condition-stunned} - @{condition-pinned})" disabled></span>
 				<span class="sheet-table-data sheet-center" style="width:48px;">= 10 +</span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" value="0" disabled></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -546,7 +575,7 @@
 			</div>
 			<div class="sheet-table-row">
 				<span class="sheet-table-row-name">Flat-Footed</span>
-				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Flat-Footed}" type="number" name="attr_Flat-Footed" value="(10 + @{AC-armor} + @{AC-shield} + @{FF-DEX} + @{size} + @{AC-natural} + @{AC-deflect} + @{AC-misc} + @{AC-temp} + @{AC-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Flat-Footed}" type="number" name="attr_Flat-Footed" value="(10 + @{AC-armor} + @{AC-shield} + @{FF-DEX} + @{size} + @{AC-natural} + @{AC-deflect} + @{AC-misc} + @{AC-temp} + @{AC-penalty} - @{condition-blinded} - @{condition-cowering} - @{condition-stunned} - @{condition-pinned})" disabled></span>
 				<span class="sheet-table-data sheet-center" style="width:48px;">= 10 +</span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{armor-acbonus}" type="number" name="attr_AC-armor" value="(@{armor-acbonus} * @{armor-equipped})" disabled></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -719,7 +748,7 @@
 			</div>
 			<div class="sheet-table-row">
 				<span class="sheet-table-row-name" ><button class="sheet-text-button" title="%{selected|Fort-Save}" type="roll" name="roll_Fort-Save" value="@{character_name}'s Fortitude save: [[1d20 + @{Fort}]]&#x00A;Save notes: @{Save-notes}">Fort</button></span>
-				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Fort}" type="number" name="attr_Fort" value="(@{total-Fort} + @{CON-mod} + @{Fort-trait} + @{Fort-enhance} + @{Fort-resist} + @{Fort-misc} + @{Fort-temp})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Fort}" type="number" name="attr_Fort" value="(@{total-Fort} + @{CON-mod} + @{Fort-trait} + @{Fort-enhance} + @{Fort-resist} + @{Fort-misc} + @{Fort-temp} - @{condition-fear} - @{condition-sickened})" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{total-Fort}" type="number" name="attr_Fort-base" value="@{total-Fort}" disabled></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -737,7 +766,7 @@
 			</div>
 			<div class="sheet-table-row">
 				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|Ref-Save}" type="roll" name="roll_Ref-Save" value="@{character_name}'s Reflex save: [[1d20 + @{Ref}]]&#x00A;Save notes: @{Save-notes}">Ref</button></span>
-				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Ref}" type="number" name="attr_Ref" value="(@{total-Ref} + @{DEX-mod} + @{Ref-trait} + @{Ref-enhance} + @{Ref-resist} + @{Ref-misc} + @{Ref-temp})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Ref}" type="number" name="attr_Ref" value="(@{total-Ref} + @{DEX-mod} + @{Ref-trait} + @{Ref-enhance} + @{Ref-resist} + @{Ref-misc} + @{Ref-temp} - @{condition-fear} - @{condition-sickened})" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{total-Ref}" type="number" name="attr_Ref-base" value="@{total-Ref}" disabled></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -755,7 +784,7 @@
 			</div>
 			<div class="sheet-table-row">
 				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|Will-Save}" type="roll" name="roll_Will-Save" value="@{character_name}'s Will save: [[1d20 + @{Will}]]&#x00A;Save notes: @{Save-notes}">Will</button></span>
-				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Will}" type="number" name="attr_Will" value="(@{total-Will} + @{WIS-mod} + @{Will-trait} + @{Will-enhance} + @{Will-resist} + @{Will-misc} + @{Will-temp})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Will}" type="number" name="attr_Will" value="(@{total-Will} + @{WIS-mod} + @{Will-trait} + @{Will-enhance} + @{Will-resist} + @{Will-misc} + @{Will-temp} - @{condition-fear} - @{condition-sickened})" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{total-Will}" type="number" name="attr_Will-base" value="@{total-Will}" disabled></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -901,7 +930,7 @@
 			</div>
 			<div class="sheet-table-row">
 				<span class="sheet-table-row-name" style="text-align:left;width:10%;"><button class="sheet-text-button" type="roll" title="%{selected|Melee-Attack-Roll}" name="roll_Melee-Attack-Roll" value="@{character_name}'s Melee Attack result: [[1d20 + @{attk-melee}]]">Melee</button></span>
-				<span class="sheet-table-data sheet-center"><input title="@{attk-melee}" type="number" name="attr_attk-melee" value="(@{bab} + @{attk-melee-ability} + @{size} + @{attk-melee-misc} + @{attk-melee-temp} + @{attk-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-melee}" type="number" name="attr_attk-melee" value="(@{bab} + @{attk-melee-ability} + @{size} + @{attk-melee-misc} + @{attk-melee-temp} + @{attk-penalty} - @{condition-dazzled} - @{condition-entangled} - @{condition-grappled} - @{condition-fear} - @{condition-sickened} - @{condition-prone} + @{condition-invisible})" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + @{class-1-bab} + @{class-2-bab} + @{class-3-bab} + @{class-4-bab})" disabled></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -928,7 +957,7 @@
 			</div>
 			<div class="sheet-table-row">
 				<span class="sheet-table-row-name" style="text-align:left;width:10%;"><button class="sheet-text-button" type="roll" title="%{selected|Ranged-Attack-Roll}" name="roll_Ranged-Attack-Roll" value="@{character_name}'s Ranged Attack result: [[1d20 + @{attk-ranged}]]">Ranged</button></span>
-				<span class="sheet-table-data sheet-center"><input title="@{attk-ranged}" type="number" name="attr_attk-ranged" value="(@{bab} + @{attk-ranged-ability} + @{size} + @{attk-ranged-misc} + @{attk-ranged-temp} + @{attk-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-ranged}" type="number" name="attr_attk-ranged" value="(@{bab} + @{attk-ranged-ability} + @{size} + @{attk-ranged-misc} + @{attk-ranged-temp} + @{attk-penalty} - @{condition-dazzled} - @{condition-entangled} - @{condition-grappled} - @{condition-fear} - @{condition-sickened} + @{condition-invisible})" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + @{class-1-bab} + @{class-2-bab} + @{class-3-bab} + @{class-4-bab})" disabled></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -955,7 +984,7 @@
 			</div>
 			<div class="sheet-table-row">
 				<span class="sheet-table-row-name" style="text-align:left;width:10%;"><button class="sheet-text-button" type="roll" title="%{selected|CMB-Check}" name="roll_CMB-Check" value="@{character_name}'s CMB check&#x00A;[[1d20 + @{CMB}]]&#x00A;CMB notes: @{cmb-notes}">CMB</button></span>
-				<span class="sheet-table-data sheet-center"><input title="@{CMB}" type="number" name="attr_CMB" value="(@{bab} + @{attk-CMB-ability} + @{attk-CMB-size} + @{attk-CMB-misc} + @{attk-CMB-temp} + @{attk-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{CMB}" type="number" name="attr_CMB" value="(@{bab} + @{attk-CMB-ability} + @{attk-CMB-size} + @{attk-CMB-misc} + @{attk-CMB-temp} + @{attk-penalty} - @{condition-dazzled} - @{condition-entangled} - @{condition-grappled} - @{condition-fear} - @{condition-sickened} + @{condition-invisible})" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + @{class-1-bab} + @{class-2-bab} + @{class-3-bab} + @{class-4-bab})" disabled></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1115,31 +1144,31 @@
 						<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_damage" title="@{repeating_weapon_X_damage}" placeholder="Damage Modifiers"><br>Damage Mods</span>
 						<span class="sheet-table-data sheet-center" style="width:15%;">
 							<select title="@{repeating_weapon_X_damage-ability}" name="attr_damage-ability">
-								<option value="0" selected>None</option>
-								<option value="floor(0.5 * @{STR-mod})">1/2 STR</option>
-								<option value="floor(0.5 * @{DEX-mod})">1/2 DEX</option>
-								<option value="floor(0.5 * @{CON-mod})">1/2 CON</option>
-								<option value="floor(0.5 * @{INT-mod})">1/2 INT</option>
-								<option value="floor(0.5 * @{WIS-mod})">1/2 WIS</option>
-								<option value="floor(0.5 * @{CHA-mod})">1/2 CHA</option>
-								<option value="@{STR-mod}">STR</option>
-								<option value="@{DEX-mod}">DEX</option>
-								<option value="@{CON-mod}">CON</option>
-								<option value="@{INT-mod}">INT</option>
-								<option value="@{WIS-mod}">WIS</option>
-								<option value="@{CHA-mod}">CHA</option>
-								<option value="floor(1.5 * @{STR-mod})">1.5x STR</option>
-								<option value="floor(1.5 * @{DEX-mod})">1.5x DEX</option>
-								<option value="floor(1.5 * @{CON-mod})">1.5x CON</option>
-								<option value="floor(1.5 * @{INT-mod})">1.5x INT</option>
-								<option value="floor(1.5 * @{WIS-mod})">1.5x WIS</option>
-								<option value="floor(1.5 * @{CHA-mod})">1.5x CHA</option>
-								<option value="floor(2 * @{STR-mod})">2x STR</option>
-								<option value="floor(2 * @{DEX-mod})">2x DEX</option>
-								<option value="floor(2 * @{CON-mod})">2x CON</option>
-								<option value="floor(2 * @{INT-mod})">2x INT</option>
-								<option value="floor(2 * @{WIS-mod})">2x WIS</option>
-								<option value="floor(2 * @{CHA-mod})">2x CHA</option>
+								<option value="0 - @{condition-sickened}" selected>None</option>
+								<option value="floor(0.5 * @{STR-mod}) - @{condition-sickened}">1/2 STR</option>
+								<option value="floor(0.5 * @{DEX-mod}) - @{condition-sickened}">1/2 DEX</option>
+								<option value="floor(0.5 * @{CON-mod}) - @{condition-sickened}">1/2 CON</option>
+								<option value="floor(0.5 * @{INT-mod}) - @{condition-sickened}">1/2 INT</option>
+								<option value="floor(0.5 * @{WIS-mod}) - @{condition-sickened}">1/2 WIS</option>
+								<option value="floor(0.5 * @{CHA-mod}) - @{condition-sickened}">1/2 CHA</option>
+								<option value="@{STR-mod} - @{condition-sickened}">STR</option>
+								<option value="@{DEX-mod} - @{condition-sickened}">DEX</option>
+								<option value="@{CON-mod} - @{condition-sickened}">CON</option>
+								<option value="@{INT-mod} - @{condition-sickened}">INT</option>
+								<option value="@{WIS-mod} - @{condition-sickened}">WIS</option>
+								<option value="@{CHA-mod} - @{condition-sickened}">CHA</option>
+								<option value="floor(1.5 * @{STR-mod}) - @{condition-sickened}">1.5x STR</option>
+								<option value="floor(1.5 * @{DEX-mod}) - @{condition-sickened}">1.5x DEX</option>
+								<option value="floor(1.5 * @{CON-mod}) - @{condition-sickened}">1.5x CON</option>
+								<option value="floor(1.5 * @{INT-mod}) - @{condition-sickened}">1.5x INT</option>
+								<option value="floor(1.5 * @{WIS-mod}) - @{condition-sickened}">1.5x WIS</option>
+								<option value="floor(1.5 * @{CHA-mod}) - @{condition-sickened}">1.5x CHA</option>
+								<option value="floor(2 * @{STR-mod}) - @{condition-sickened}">2x STR</option>
+								<option value="floor(2 * @{DEX-mod}) - @{condition-sickened}">2x DEX</option>
+								<option value="floor(2 * @{CON-mod}) - @{condition-sickened}">2x CON</option>
+								<option value="floor(2 * @{INT-mod}) - @{condition-sickened}">2x INT</option>
+								<option value="floor(2 * @{WIS-mod}) - @{condition-sickened}">2x WIS</option>
+								<option value="floor(2 * @{CHA-mod}) - @{condition-sickened}">2x CHA</option>
 							</select>
 							<br>Damage Ability
 						</span>
@@ -1234,7 +1263,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics-cs}" type="checkbox" name="attr_Acrobatics-cs" value="((((3 * @{Acrobatics-ranks}) + 3) - abs((3 * @{Acrobatics-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Acrobatics</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics}" type="number" name="attr_Acrobatics" value="(@{Acrobatics-ranks} + @{Acrobatics-class} + @{Acrobatics-ability} + @{Acrobatics-racial} + @{Acrobatics-feat} + @{Acrobatics-item} + @{Acrobatics-acp} + @{Acrobatics-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics}" type="number" name="attr_Acrobatics" value="(@{Acrobatics-ranks} + @{Acrobatics-class} + @{Acrobatics-ability} + @{Acrobatics-racial} + @{Acrobatics-feat} + @{Acrobatics-item} + @{Acrobatics-acp} + @{Acrobatics-misc} - @{condition-fear} - @{condition-sickened})" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics-ranks}" type="number" name="attr_Acrobatics-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1267,7 +1296,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Appraise-cs}" type="checkbox" name="attr_Appraise-cs" value="((((3 * @{Appraise-ranks}) + 3) - abs((3 * @{Appraise-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Appraise</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Appraise}" type="number" name="attr_Appraise" value="(@{Appraise-ranks} + @{Appraise-class} + @{Appraise-ability} + @{Appraise-racial} + @{Appraise-feat} + @{Appraise-item} + @{Appraise-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Appraise}" type="number" name="attr_Appraise" value="(@{Appraise-ranks} + @{Appraise-class} + @{Appraise-ability} + @{Appraise-racial} + @{Appraise-feat} + @{Appraise-item} + @{Appraise-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Appraise-ranks}" type="number" name="attr_Appraise-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1300,7 +1329,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Bluff-cs}" type="checkbox" name="attr_Bluff-cs" value="((((3 * @{Bluff-ranks}) + 3) - abs((3 * @{Bluff-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Bluff</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Bluff}" type="number" name="attr_Bluff" value="(@{Bluff-ranks} + @{Bluff-class} + @{Bluff-ability} + @{Bluff-racial} + @{Bluff-feat} + @{Bluff-item} + @{Bluff-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Bluff}" type="number" name="attr_Bluff" value="(@{Bluff-ranks} + @{Bluff-class} + @{Bluff-ability} + @{Bluff-racial} + @{Bluff-feat} + @{Bluff-item} + @{Bluff-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Bluff-ranks}" type="number" name="attr_Bluff-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1333,7 +1362,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Climb-cs}" type="checkbox" name="attr_Climb-cs" value="((((3 * @{Climb-ranks}) + 3) - abs((3 * @{Climb-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Climb</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Climb}" type="number" name="attr_Climb" value="(@{Climb-ranks} + @{Climb-class} + @{Climb-ability} + @{Climb-racial} + @{Climb-feat} + @{Climb-item} + @{Climb-acp} + @{Climb-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Climb}" type="number" name="attr_Climb" value="(@{Climb-ranks} + @{Climb-class} + @{Climb-ability} + @{Climb-racial} + @{Climb-feat} + @{Climb-item} + @{Climb-acp} + @{Climb-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Climb-ranks}" type="number" name="attr_Climb-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1366,7 +1395,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Craft-cs}" type="checkbox" name="attr_Craft-cs" value="((((3 * @{Craft-ranks}) + 3) - abs((3 * @{Craft-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft-name}" style="width:auto;" type="text" name="attr_Craft-name"></span>
-				<span class="sheet-table-data sheet-center"><input title="@{Craft}" type="number" name="attr_Craft" value="(@{Craft-ranks} + @{Craft-class} + @{Craft-ability} + @{Craft-racial} + @{Craft-feat} + @{Craft-item} + @{Craft-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft}" type="number" name="attr_Craft" value="(@{Craft-ranks} + @{Craft-class} + @{Craft-ability} + @{Craft-racial} + @{Craft-feat} + @{Craft-item} + @{Craft-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Craft-ranks}" type="number" name="attr_Craft-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1399,7 +1428,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Craft2-cs}" type="checkbox" name="attr_Craft2-cs" value="((((3 * @{Craft2-ranks}) + 3) - abs((3 * @{Craft2-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft2-name}" style="width:auto;" type="text" name="attr_Craft2-name"></span>
-				<span class="sheet-table-data sheet-center"><input title="@{Craft2}" type="number" name="attr_Craft2" value="(@{Craft2-ranks} + @{Craft2-class} + @{Craft2-ability} + @{Craft2-racial} + @{Craft2-feat} + @{Craft2-item} + @{Craft2-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft2}" type="number" name="attr_Craft2" value="(@{Craft2-ranks} + @{Craft2-class} + @{Craft2-ability} + @{Craft2-racial} + @{Craft2-feat} + @{Craft2-item} + @{Craft2-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Craft2-ranks}" type="number" name="attr_Craft2-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1432,7 +1461,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Craft3-cs}" type="checkbox" name="attr_Craft3-cs" value="((((3 * @{Craft3-ranks}) + 3) - abs((3 * @{Craft3-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft3-name}" style="width:auto;" type="text" name="attr_Craft3-name"></span>
-				<span class="sheet-table-data sheet-center"><input title="@{Craft3}" type="number" name="attr_Craft3" value="(@{Craft3-ranks} + @{Craft3-class} + @{Craft3-ability} + @{Craft3-racial} + @{Craft3-feat} + @{Craft3-item} + @{Craft3-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft3}" type="number" name="attr_Craft3" value="(@{Craft3-ranks} + @{Craft3-class} + @{Craft3-ability} + @{Craft3-racial} + @{Craft3-feat} + @{Craft3-item} + @{Craft3-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Craft3-ranks}" type="number" name="attr_Craft3-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1465,7 +1494,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy-cs}" type="checkbox" name="attr_Diplomacy-cs" value="((((3 * @{Diplomacy-ranks}) + 3) - abs((3 * @{Diplomacy-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Diplomacy</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy}" type="number" name="attr_Diplomacy" value="(@{Diplomacy-ranks} + @{Diplomacy-class} + @{Diplomacy-ability} + @{Diplomacy-racial} + @{Diplomacy-feat} + @{Diplomacy-item} + @{Diplomacy-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy}" type="number" name="attr_Diplomacy" value="(@{Diplomacy-ranks} + @{Diplomacy-class} + @{Diplomacy-ability} + @{Diplomacy-racial} + @{Diplomacy-feat} + @{Diplomacy-item} + @{Diplomacy-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy-ranks}" type="number" name="attr_Diplomacy-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1498,7 +1527,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-cs}" type="checkbox" name="attr_Disable-Device-cs" value="((((3 * @{Disable-Device-ranks}) + 3) - abs((3 * @{Disable-Device-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Disable Device</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device}" type="number" name="attr_Disable-Device" value="(@{Disable-Device-ranks} + @{Disable-Device-class} + @{Disable-Device-ability} + @{Disable-Device-racial} + @{Disable-Device-feat} + @{Disable-Device-item} + @{Disable-Device-acp} + @{Disable-Device-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device}" type="number" name="attr_Disable-Device" value="(@{Disable-Device-ranks} + @{Disable-Device-class} + @{Disable-Device-ability} + @{Disable-Device-racial} + @{Disable-Device-feat} + @{Disable-Device-item} + @{Disable-Device-acp} + @{Disable-Device-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-ranks}" type="number" name="attr_Disable-Device-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1531,7 +1560,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Disguise-cs}" type="checkbox" name="attr_Disguise-cs" value="((((3 * @{Disguise-ranks}) + 3) - abs((3 * @{Disguise-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Disguise</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Disguise}" type="number" name="attr_Disguise" value="(@{Disguise-ranks} + @{Disguise-class} + @{Disguise-ability} + @{Disguise-racial} + @{Disguise-feat} + @{Disguise-item} + @{Disguise-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disguise}" type="number" name="attr_Disguise" value="(@{Disguise-ranks} + @{Disguise-class} + @{Disguise-ability} + @{Disguise-racial} + @{Disguise-feat} + @{Disguise-item} + @{Disguise-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Disguise-ranks}" type="number" name="attr_Disguise-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1564,7 +1593,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-cs}" type="checkbox" name="attr_Escape-Artist-cs" value="((((3 * @{Escape-Artist-ranks}) + 3) - abs((3 * @{Escape-Artist-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Escape Artist</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist}" type="number" name="attr_Escape-Artist" value="(@{Escape-Artist-ranks} + @{Escape-Artist-class} + @{Escape-Artist-ability} + @{Escape-Artist-racial} + @{Escape-Artist-feat} + @{Escape-Artist-item} + @{Escape-Artist-acp} + @{Escape-Artist-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist}" type="number" name="attr_Escape-Artist" value="(@{Escape-Artist-ranks} + @{Escape-Artist-class} + @{Escape-Artist-ability} + @{Escape-Artist-racial} + @{Escape-Artist-feat} + @{Escape-Artist-item} + @{Escape-Artist-acp} + @{Escape-Artist-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-ranks}" type="number" name="attr_Escape-Artist-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1597,7 +1626,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Fly-cs}" type="checkbox" name="attr_Fly-cs" value="((((3 * @{Fly-ranks}) + 3) - abs((3 * @{Fly-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Fly</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Fly}" type="number" name="attr_Fly" value="(@{Fly-ranks} + @{Fly-class} + @{Fly-ability} + @{Fly-racial} + @{Fly-feat} + @{Fly-item} + @{Fly-acp} + @{Fly-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Fly}" type="number" name="attr_Fly" value="(@{Fly-ranks} + @{Fly-class} + @{Fly-ability} + @{Fly-racial} + @{Fly-feat} + @{Fly-item} + @{Fly-acp} + @{Fly-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Fly-ranks}" type="number" name="attr_Fly-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1630,7 +1659,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-cs}" type="checkbox" name="attr_Handle-Animal-cs" value="((((3 * @{Handle-Animal-ranks}) + 3) - abs((3 * @{Handle-Animal-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Handle Animal</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal}" type="number" name="attr_Handle-Animal" value="(@{Handle-Animal-ranks} + @{Handle-Animal-class} + @{Handle-Animal-ability} + @{Handle-Animal-racial} + @{Handle-Animal-feat} + @{Handle-Animal-item} + @{Handle-Animal-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal}" type="number" name="attr_Handle-Animal" value="(@{Handle-Animal-ranks} + @{Handle-Animal-class} + @{Handle-Animal-ability} + @{Handle-Animal-racial} + @{Handle-Animal-feat} + @{Handle-Animal-item} + @{Handle-Animal-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-ranks}" type="number" name="attr_Handle-Animal-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1663,7 +1692,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Heal-cs}" type="checkbox" name="attr_Heal-cs" value="((((3 * @{Heal-ranks}) + 3) - abs((3 * @{Heal-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Heal</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Heal}" type="number" name="attr_Heal" value="(@{Heal-ranks} + @{Heal-class} + @{Heal-ability} + @{Heal-racial} + @{Heal-feat} + @{Heal-item} + @{Heal-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Heal}" type="number" name="attr_Heal" value="(@{Heal-ranks} + @{Heal-class} + @{Heal-ability} + @{Heal-racial} + @{Heal-feat} + @{Heal-item} + @{Heal-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Heal-ranks}" type="number" name="attr_Heal-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1696,7 +1725,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Intimidate-cs}" type="checkbox" name="attr_Intimidate-cs" value="((((3 * @{Intimidate-ranks}) + 3) - abs((3 * @{Intimidate-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Intimidate</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Intimidate}" type="number" name="attr_Intimidate" value="(@{Intimidate-ranks} + @{Intimidate-class} + @{Intimidate-ability} + @{Intimidate-racial} + @{Intimidate-feat} + @{Intimidate-item} + @{Intimidate-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Intimidate}" type="number" name="attr_Intimidate" value="(@{Intimidate-ranks} + @{Intimidate-class} + @{Intimidate-ability} + @{Intimidate-racial} + @{Intimidate-feat} + @{Intimidate-item} + @{Intimidate-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Intimidate-ranks}" type="number" name="attr_Intimidate-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1729,7 +1758,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-cs}" type="checkbox" name="attr_Knowledge-Arcana-cs" value="((((3 * @{Knowledge-Arcana-ranks}) + 3) - abs((3 * @{Knowledge-Arcana-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Knowledge (Arcana)</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana}" type="number" name="attr_Knowledge-Arcana" value="(@{Knowledge-Arcana-ranks} + @{Knowledge-Arcana-class} + @{Knowledge-Arcana-ability} + @{Knowledge-Arcana-racial} + @{Knowledge-Arcana-feat} + @{Knowledge-Arcana-item} + @{Knowledge-Arcana-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana}" type="number" name="attr_Knowledge-Arcana" value="(@{Knowledge-Arcana-ranks} + @{Knowledge-Arcana-class} + @{Knowledge-Arcana-ability} + @{Knowledge-Arcana-racial} + @{Knowledge-Arcana-feat} + @{Knowledge-Arcana-item} + @{Knowledge-Arcana-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-ranks}" type="number" name="attr_Knowledge-Arcana-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1762,7 +1791,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-cs}" type="checkbox" name="attr_Knowledge-Dungeoneering-cs" value="((((3 * @{Knowledge-Dungeoneering-ranks}) + 3) - abs((3 * @{Knowledge-Dungeoneering-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Knowledge (Dungeoneering)</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering}" type="number" name="attr_Knowledge-Dungeoneering" value="(@{Knowledge-Dungeoneering-ranks} + @{Knowledge-Dungeoneering-class} + @{Knowledge-Dungeoneering-ability} + @{Knowledge-Dungeoneering-racial} + @{Knowledge-Dungeoneering-feat} + @{Knowledge-Dungeoneering-item} + @{Knowledge-Dungeoneering-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering}" type="number" name="attr_Knowledge-Dungeoneering" value="(@{Knowledge-Dungeoneering-ranks} + @{Knowledge-Dungeoneering-class} + @{Knowledge-Dungeoneering-ability} + @{Knowledge-Dungeoneering-racial} + @{Knowledge-Dungeoneering-feat} + @{Knowledge-Dungeoneering-item} + @{Knowledge-Dungeoneering-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-ranks}" type="number" name="attr_Knowledge-Dungeoneering-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1795,7 +1824,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-cs}" type="checkbox" name="attr_Knowledge-Engineering-cs" value="((((3 * @{Knowledge-Engineering-ranks}) + 3) - abs((3 * @{Knowledge-Engineering-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Knowledge (Engineering)</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering}" type="number" name="attr_Knowledge-Engineering" value="(@{Knowledge-Engineering-ranks} + @{Knowledge-Engineering-class} + @{Knowledge-Engineering-ability} + @{Knowledge-Engineering-racial} + @{Knowledge-Engineering-feat} + @{Knowledge-Engineering-item} + @{Knowledge-Engineering-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering}" type="number" name="attr_Knowledge-Engineering" value="(@{Knowledge-Engineering-ranks} + @{Knowledge-Engineering-class} + @{Knowledge-Engineering-ability} + @{Knowledge-Engineering-racial} + @{Knowledge-Engineering-feat} + @{Knowledge-Engineering-item} + @{Knowledge-Engineering-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-ranks}" type="number" name="attr_Knowledge-Engineering-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1828,7 +1857,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-cs}" type="checkbox" name="attr_Knowledge-Geography-cs" value="((((3 * @{Knowledge-Geography-ranks}) + 3) - abs((3 * @{Knowledge-Geography-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Knowledge (Geography)</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography}" type="number" name="attr_Knowledge-Geography" value="(@{Knowledge-Geography-ranks} + @{Knowledge-Geography-class} + @{Knowledge-Geography-ability} + @{Knowledge-Geography-racial} + @{Knowledge-Geography-feat} + @{Knowledge-Geography-item} + @{Knowledge-Geography-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography}" type="number" name="attr_Knowledge-Geography" value="(@{Knowledge-Geography-ranks} + @{Knowledge-Geography-class} + @{Knowledge-Geography-ability} + @{Knowledge-Geography-racial} + @{Knowledge-Geography-feat} + @{Knowledge-Geography-item} + @{Knowledge-Geography-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-ranks}" type="number" name="attr_Knowledge-Geography-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1861,7 +1890,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-cs}" type="checkbox" name="attr_Knowledge-History-cs" value="((((3 * @{Knowledge-History-ranks}) + 3) - abs((3 * @{Knowledge-History-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Knowledge (History)</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History}" type="number" name="attr_Knowledge-History" value="(@{Knowledge-History-ranks} + @{Knowledge-History-class} + @{Knowledge-History-ability} + @{Knowledge-History-racial} + @{Knowledge-History-feat} + @{Knowledge-History-item} + @{Knowledge-History-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History}" type="number" name="attr_Knowledge-History" value="(@{Knowledge-History-ranks} + @{Knowledge-History-class} + @{Knowledge-History-ability} + @{Knowledge-History-racial} + @{Knowledge-History-feat} + @{Knowledge-History-item} + @{Knowledge-History-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-ranks}" type="number" name="attr_Knowledge-History-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1894,7 +1923,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-cs}" type="checkbox" name="attr_Knowledge-Local-cs" value="((((3 * @{Knowledge-Local-ranks}) + 3) - abs((3 * @{Knowledge-Local-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Knowledge (Local)</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local}" type="number" name="attr_Knowledge-Local" value="(@{Knowledge-Local-ranks} + @{Knowledge-Local-class} + @{Knowledge-Local-ability} + @{Knowledge-Local-racial} + @{Knowledge-Local-feat} + @{Knowledge-Local-item} + @{Knowledge-Local-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local}" type="number" name="attr_Knowledge-Local" value="(@{Knowledge-Local-ranks} + @{Knowledge-Local-class} + @{Knowledge-Local-ability} + @{Knowledge-Local-racial} + @{Knowledge-Local-feat} + @{Knowledge-Local-item} + @{Knowledge-Local-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-ranks}" type="number" name="attr_Knowledge-Local-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1927,7 +1956,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-cs}" type="checkbox" name="attr_Knowledge-Nature-cs" value="((((3 * @{Knowledge-Nature-ranks}) + 3) - abs((3 * @{Knowledge-Nature-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Knowledge (Nature)</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature}" type="number" name="attr_Knowledge-Nature" value="(@{Knowledge-Nature-ranks} + @{Knowledge-Nature-class} + @{Knowledge-Nature-ability} + @{Knowledge-Nature-racial} + @{Knowledge-Nature-feat} + @{Knowledge-Nature-item} + @{Knowledge-Nature-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature}" type="number" name="attr_Knowledge-Nature" value="(@{Knowledge-Nature-ranks} + @{Knowledge-Nature-class} + @{Knowledge-Nature-ability} + @{Knowledge-Nature-racial} + @{Knowledge-Nature-feat} + @{Knowledge-Nature-item} + @{Knowledge-Nature-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-ranks}" type="number" name="attr_Knowledge-Nature-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1960,7 +1989,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-cs}" type="checkbox" name="attr_Knowledge-Nobility-cs" value="((((3 * @{Knowledge-Nobility-ranks}) + 3) - abs((3 * @{Knowledge-Nobility-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Knowledge (Nobility)</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility}" type="number" name="attr_Knowledge-Nobility" value="(@{Knowledge-Nobility-ranks} + @{Knowledge-Nobility-class} + @{Knowledge-Nobility-ability} + @{Knowledge-Nobility-racial} + @{Knowledge-Nobility-feat} + @{Knowledge-Nobility-item} + @{Knowledge-Nobility-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility}" type="number" name="attr_Knowledge-Nobility" value="(@{Knowledge-Nobility-ranks} + @{Knowledge-Nobility-class} + @{Knowledge-Nobility-ability} + @{Knowledge-Nobility-racial} + @{Knowledge-Nobility-feat} + @{Knowledge-Nobility-item} + @{Knowledge-Nobility-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-ranks}" type="number" name="attr_Knowledge-Nobility-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -1993,7 +2022,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-cs}" type="checkbox" name="attr_Knowledge-Planes-cs" value="((((3 * @{Knowledge-Planes-ranks}) + 3) - abs((3 * @{Knowledge-Planes-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Knowledge (Planes)</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes}" type="number" name="attr_Knowledge-Planes" value="(@{Knowledge-Planes-ranks} + @{Knowledge-Planes-class} + @{Knowledge-Planes-ability} + @{Knowledge-Planes-racial} + @{Knowledge-Planes-feat} + @{Knowledge-Planes-item} + @{Knowledge-Planes-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes}" type="number" name="attr_Knowledge-Planes" value="(@{Knowledge-Planes-ranks} + @{Knowledge-Planes-class} + @{Knowledge-Planes-ability} + @{Knowledge-Planes-racial} + @{Knowledge-Planes-feat} + @{Knowledge-Planes-item} + @{Knowledge-Planes-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-ranks}" type="number" name="attr_Knowledge-Planes-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2026,7 +2055,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-cs}" type="checkbox" name="attr_Knowledge-Religion-cs" value="((((3 * @{Knowledge-Religion-ranks}) + 3) - abs((3 * @{Knowledge-Religion-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Knowledge (Religion)</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion}" type="number" name="attr_Knowledge-Religion" value="(@{Knowledge-Religion-ranks} + @{Knowledge-Religion-class} + @{Knowledge-Religion-ability} + @{Knowledge-Religion-racial} + @{Knowledge-Religion-feat} + @{Knowledge-Religion-item} + @{Knowledge-Religion-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion}" type="number" name="attr_Knowledge-Religion" value="(@{Knowledge-Religion-ranks} + @{Knowledge-Religion-class} + @{Knowledge-Religion-ability} + @{Knowledge-Religion-racial} + @{Knowledge-Religion-feat} + @{Knowledge-Religion-item} + @{Knowledge-Religion-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-ranks}" type="number" name="attr_Knowledge-Religion-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2059,7 +2088,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Linguistics-cs}" type="checkbox" name="attr_Linguistics-cs" value="((((3 * @{Linguistics-ranks}) + 3) - abs((3 * @{Linguistics-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Linguistics</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Linguistics}" type="number" name="attr_Linguistics" value="(@{Linguistics-ranks} + @{Linguistics-class} + @{Linguistics-ability} + @{Linguistics-racial} + @{Linguistics-feat} + @{Linguistics-item} + @{Linguistics-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Linguistics}" type="number" name="attr_Linguistics" value="(@{Linguistics-ranks} + @{Linguistics-class} + @{Linguistics-ability} + @{Linguistics-racial} + @{Linguistics-feat} + @{Linguistics-item} + @{Linguistics-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Linguistics-ranks}" type="number" name="attr_Linguistics-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2083,6 +2112,7 @@
 				<span class="sheet-table-data sheet-center">+</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Linguistics-item}" type="number" name="attr_Linguistics-item" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
+
 				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
 				<span class="sheet-table-data sheet-center">+</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Linguistics-misc}" type="number" name="attr_Linguistics-misc" value="0"></span>
@@ -2092,7 +2122,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Perception-cs}" type="checkbox" name="attr_Perception-cs" value="((((3 * @{Perception-ranks}) + 3) - abs((3 * @{Perception-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Perception</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Perception}" type="number" name="attr_Perception" value="(@{Perception-ranks} + @{Perception-class} + @{Perception-ability} + @{Perception-racial} + @{Perception-feat} + @{Perception-item} + @{Perception-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perception}" type="number" name="attr_Perception" value="(@{Perception-ranks} + @{Perception-class} + @{Perception-ability} + @{Perception-racial} + @{Perception-feat} + @{Perception-item} + @{Perception-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Perception-ranks}" type="number" name="attr_Perception-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2125,7 +2155,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Perform-cs}" type="checkbox" name="attr_Perform-cs" value="((((3 * @{Perform-ranks}) + 3) - abs((3 * @{Perform-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform-name}" style="width:auto;" type="text" name="attr_Perform-name"></span>
-				<span class="sheet-table-data sheet-center"><input title="@{Perform}" type="number" name="attr_Perform" value="(@{Perform-ranks} + @{Perform-class} + @{Perform-ability} + @{Perform-racial} + @{Perform-feat} + @{Perform-item} + @{Perform-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform}" type="number" name="attr_Perform" value="(@{Perform-ranks} + @{Perform-class} + @{Perform-ability} + @{Perform-racial} + @{Perform-feat} + @{Perform-item} + @{Perform-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Perform-ranks}" type="number" name="attr_Perform-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2158,7 +2188,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Perform2-cs}" type="checkbox" name="attr_Perform2-cs" value="((((3 * @{Perform2-ranks}) + 3) - abs((3 * @{Perform2-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform2-name}" style="width:auto;" type="text" name="attr_Perform2-name"></span>
-				<span class="sheet-table-data sheet-center"><input title="@{Perform2}" type="number" name="attr_Perform2" value="(@{Perform2-ranks} + @{Perform2-class} + @{Perform2-ability} + @{Perform2-racial} + @{Perform2-feat} + @{Perform2-item} + @{Perform2-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform2}" type="number" name="attr_Perform2" value="(@{Perform2-ranks} + @{Perform2-class} + @{Perform2-ability} + @{Perform2-racial} + @{Perform2-feat} + @{Perform2-item} + @{Perform2-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Perform2-ranks}" type="number" name="attr_Perform2-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2191,7 +2221,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Perform3-cs}" type="checkbox" name="attr_Perform3-cs" value="((((3 * @{Perform3-ranks}) + 3) - abs((3 * @{Perform3-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform3-name}" style="width:auto;" type="text" name="attr_Perform3-name"></span>
-				<span class="sheet-table-data sheet-center"><input title="@{Perform3}" type="number" name="attr_Perform3" value="(@{Perform3-ranks} + @{Perform3-class} + @{Perform3-ability} + @{Perform3-racial} + @{Perform3-feat} + @{Perform3-item} + @{Perform3-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform3}" type="number" name="attr_Perform3" value="(@{Perform3-ranks} + @{Perform3-class} + @{Perform3-ability} + @{Perform3-racial} + @{Perform3-feat} + @{Perform3-item} + @{Perform3-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Perform3-ranks}" type="number" name="attr_Perform3-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2224,7 +2254,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Profession-cs}" type="checkbox" name="attr_Profession-cs" value="((((3 * @{Profession-ranks}) + 3) - abs((3 * @{Profession-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession-name}" style="width:auto;" type="text" name="attr_Profession-name"></span>
-				<span class="sheet-table-data sheet-center"><input title="@{Profession}" type="number" name="attr_Profession" value="(@{Profession-ranks} + @{Profession-class} + @{Profession-ability} + @{Profession-racial} + @{Profession-feat} + @{Profession-item} + @{Profession-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession}" type="number" name="attr_Profession" value="(@{Profession-ranks} + @{Profession-class} + @{Profession-ability} + @{Profession-racial} + @{Profession-feat} + @{Profession-item} + @{Profession-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Profession-ranks}" type="number" name="attr_Profession-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2257,7 +2287,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Profession2-cs}" type="checkbox" name="attr_Profession2-cs" value="((((3 * @{Profession2-ranks}) + 3) - abs((3 * @{Profession2-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession2-name}" style="width:auto;" type="text" name="attr_Profession2-name"></span>
-				<span class="sheet-table-data sheet-center"><input title="@{Profession2}" type="number" name="attr_Profession2" value="(@{Profession2-ranks} + @{Profession2-class} + @{Profession2-ability} + @{Profession2-racial} + @{Profession2-feat} + @{Profession2-item} + @{Profession2-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession2}" type="number" name="attr_Profession2" value="(@{Profession2-ranks} + @{Profession2-class} + @{Profession2-ability} + @{Profession2-racial} + @{Profession2-feat} + @{Profession2-item} + @{Profession2-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Profession2-ranks}" type="number" name="attr_Profession2-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2290,7 +2320,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Profession3-cs}" type="checkbox" name="attr_Profession3-cs" value="((((3 * @{Profession3-ranks}) + 3) - abs((3 * @{Profession3-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession3-name}" style="width:auto;" type="text" name="attr_Profession3-name"></span>
-				<span class="sheet-table-data sheet-center"><input title="@{Profession3}" type="number" name="attr_Profession3" value="(@{Profession3-ranks} + @{Profession3-class} + @{Profession3-ability} + @{Profession3-racial} + @{Profession3-feat} + @{Profession3-item} + @{Profession3-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession3}" type="number" name="attr_Profession3" value="(@{Profession3-ranks} + @{Profession3-class} + @{Profession3-ability} + @{Profession3-racial} + @{Profession3-feat} + @{Profession3-item} + @{Profession3-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Profession3-ranks}" type="number" name="attr_Profession3-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2323,7 +2353,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Ride-cs}" type="checkbox" name="attr_Ride-cs" value="((((3 * @{Ride-ranks}) + 3) - abs((3 * @{Ride-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Ride</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Ride}" type="number" name="attr_Ride" value="(@{Ride-ranks} + @{Ride-class} + @{Ride-ability} + @{Ride-racial} + @{Ride-feat} + @{Ride-item} + @{Ride-acp} + @{Ride-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Ride}" type="number" name="attr_Ride" value="(@{Ride-ranks} + @{Ride-class} + @{Ride-ability} + @{Ride-racial} + @{Ride-feat} + @{Ride-item} + @{Ride-acp} + @{Ride-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Ride-ranks}" type="number" name="attr_Ride-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2356,7 +2386,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-cs}" type="checkbox" name="attr_Sense-Motive-cs" value="((((3 * @{Sense-Motive-ranks}) + 3) - abs((3 * @{Sense-Motive-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Sense Motive</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive}" type="number" name="attr_Sense-Motive" value="(@{Sense-Motive-ranks} + @{Sense-Motive-class} + @{Sense-Motive-ability} + @{Sense-Motive-racial} + @{Sense-Motive-feat} + @{Sense-Motive-item} + @{Sense-Motive-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive}" type="number" name="attr_Sense-Motive" value="(@{Sense-Motive-ranks} + @{Sense-Motive-class} + @{Sense-Motive-ability} + @{Sense-Motive-racial} + @{Sense-Motive-feat} + @{Sense-Motive-item} + @{Sense-Motive-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-ranks}" type="number" name="attr_Sense-Motive-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2389,7 +2419,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-cs}" type="checkbox" name="attr_Sleight-of-Hand-cs" value="((((3 * @{Sleight-of-Hand-ranks}) + 3) - abs((3 * @{Sleight-of-Hand-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Sleight of Hand</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand}" type="number" name="attr_Sleight-of-Hand" value="(@{Sleight-of-Hand-ranks} + @{Sleight-of-Hand-class} + @{Sleight-of-Hand-ability} + @{Sleight-of-Hand-racial} + @{Sleight-of-Hand-feat} + @{Sleight-of-Hand-item} + @{Sleight-of-Hand-acp} + @{Sleight-of-Hand-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand}" type="number" name="attr_Sleight-of-Hand" value="(@{Sleight-of-Hand-ranks} + @{Sleight-of-Hand-class} + @{Sleight-of-Hand-ability} + @{Sleight-of-Hand-racial} + @{Sleight-of-Hand-feat} + @{Sleight-of-Hand-item} + @{Sleight-of-Hand-acp} + @{Sleight-of-Hand-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-ranks}" type="number" name="attr_Sleight-of-Hand-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2422,7 +2452,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft-cs}" type="checkbox" name="attr_Spellcraft-cs" value="((((3 * @{Spellcraft-ranks}) + 3) - abs((3 * @{Spellcraft-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Spellcraft</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft}" type="number" name="attr_Spellcraft" value="(@{Spellcraft-ranks} + @{Spellcraft-class} + @{Spellcraft-ability} + @{Spellcraft-racial} + @{Spellcraft-feat} + @{Spellcraft-item} + @{Spellcraft-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft}" type="number" name="attr_Spellcraft" value="(@{Spellcraft-ranks} + @{Spellcraft-class} + @{Spellcraft-ability} + @{Spellcraft-racial} + @{Spellcraft-feat} + @{Spellcraft-item} + @{Spellcraft-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft-ranks}" type="number" name="attr_Spellcraft-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2455,7 +2485,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Stealth-cs}" type="checkbox" name="attr_Stealth-cs" value="((((3 * @{Stealth-ranks}) + 3) - abs((3 * @{Stealth-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Stealth</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Stealth}" type="number" name="attr_Stealth" value="(@{Stealth-ranks} + @{Stealth-class} + @{Stealth-ability} + @{Stealth-racial} + @{Stealth-feat} + @{Stealth-item} + @{Stealth-acp} + @{Stealth-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Stealth}" type="number" name="attr_Stealth" value="(@{Stealth-ranks} + @{Stealth-class} + @{Stealth-ability} + @{Stealth-racial} + @{Stealth-feat} + @{Stealth-item} + @{Stealth-acp} + @{Stealth-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Stealth-ranks}" type="number" name="attr_Stealth-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2488,7 +2518,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Survival-cs}" type="checkbox" name="attr_Survival-cs" value="((((3 * @{Survival-ranks}) + 3) - abs((3 * @{Survival-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Survival</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Survival}" type="number" name="attr_Survival" value="(@{Survival-ranks} + @{Survival-class} + @{Survival-ability} + @{Survival-racial} + @{Survival-feat} + @{Survival-item} + @{Survival-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Survival}" type="number" name="attr_Survival" value="(@{Survival-ranks} + @{Survival-class} + @{Survival-ability} + @{Survival-racial} + @{Survival-feat} + @{Survival-item} + @{Survival-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Survival-ranks}" type="number" name="attr_Survival-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2521,7 +2551,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Swim-cs}" type="checkbox" name="attr_Swim-cs" value="((((3 * @{Swim-ranks}) + 3) - abs((3 * @{Swim-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center">*</span>
 				<span class="sheet-table-data sheet-left">Swim</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Swim}" type="number" name="attr_Swim" value="(@{Swim-ranks} + @{Swim-class} + @{Swim-ability} + @{Swim-racial} + @{Swim-feat} + @{Swim-item} + @{Swim-acp} + @{Swim-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Swim}" type="number" name="attr_Swim" value="(@{Swim-ranks} + @{Swim-class} + @{Swim-ability} + @{Swim-racial} + @{Swim-feat} + @{Swim-item} + @{Swim-acp} + @{Swim-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Swim-ranks}" type="number" name="attr_Swim-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -2554,7 +2584,7 @@
 				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-cs}" type="checkbox" name="attr_Use-Magic-Device-cs" value="((((3 * @{Use-Magic-Device-ranks}) + 3) - abs((3 * @{Use-Magic-Device-ranks}) - 3)) / 2)" /></span>
 				<span class="sheet-table-data sheet-center"></span>
 				<span class="sheet-table-data sheet-left">Use Magic Device</span>
-				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device}" type="number" name="attr_Use-Magic-Device" value="(@{Use-Magic-Device-ranks} + @{Use-Magic-Device-class} + @{Use-Magic-Device-ability} + @{Use-Magic-Device-racial} + @{Use-Magic-Device-feat} + @{Use-Magic-Device-item} + @{Use-Magic-Device-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device}" type="number" name="attr_Use-Magic-Device" value="(@{Use-Magic-Device-ranks} + @{Use-Magic-Device-class} + @{Use-Magic-Device-ability} + @{Use-Magic-Device-racial} + @{Use-Magic-Device-feat} + @{Use-Magic-Device-item} + @{Use-Magic-Device-misc}) - @{condition-fear} - @{condition-sickened}" disabled></span>
 				<span class="sheet-table-data sheet-center">=</span>
 				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-ranks}" type="number" name="attr_Use-Magic-Device-ranks" value="0"></span>
 				<span class="sheet-table-data sheet-center">+</span>
@@ -3090,6 +3120,7 @@
 				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_23_Display" title="%{selected|repeating_item_23_Display}" value="/em is using their item, @{repeating_item_23_name}&#x00A;@{repeating_item_23_short-description}&#x00A;@{repeating_item_23_name} uses remaining: [[@{repeating_item_23_qty}-1]]"></button></span>
 				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_24_Display" title="%{selected|repeating_item_24_Display}" value="/em is using their item, @{repeating_item_24_name}&#x00A;@{repeating_item_24_short-description}&#x00A;@{repeating_item_24_name} uses remaining: [[@{repeating_item_24_qty}-1]]"></button></span>
 				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_25_Display" title="%{selected|repeating_item_25_Display}" value="/em is using their item, @{repeating_item_25_name}&#x00A;@{repeating_item_25_short-description}&#x00A;@{repeating_item_25_name} uses remaining: [[@{repeating_item_25_qty}-1]]"></button></span>
+
 				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_26_Display" title="%{selected|repeating_item_26_Display}" value="/em is using their item, @{repeating_item_26_name}&#x00A;@{repeating_item_26_short-description}&#x00A;@{repeating_item_26_name} uses remaining: [[@{repeating_item_26_qty}-1]]"></button></span>
 			</div>
 		</div>
@@ -5402,7 +5433,6 @@
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility}" type="number" name="attr_Knowledge-Nobility" value="(@{Knowledge-Nobility-ranks} + @{Knowledge-Nobility-class} + @{Knowledge-Nobility-ability} + @{Knowledge-Nobility-racial} + @{Knowledge-Nobility-feat} + @{Knowledge-Nobility-item} + @{Knowledge-Nobility-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-misc}" type="number" name="attr_Knowledge-Nobility-misc" value="0"></span>
 	
-
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Planes-Check}" type="roll" value="/w gm @{character_name}'s Knowledge (Planes) check: [[1d20 + @{Knowledge-Planes}]]" name="roll_NPC-Knowledge-Planes-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Knowledge (Planes)</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes}" type="number" name="attr_Knowledge-Planes" value="(@{Knowledge-Planes-ranks} + @{Knowledge-Planes-class} + @{Knowledge-Planes-ability} + @{Knowledge-Planes-racial} + @{Knowledge-Planes-feat} + @{Knowledge-Planes-item} + @{Knowledge-Planes-misc})" disabled></span>
@@ -5592,7 +5622,7 @@
 	</div>
 </div>
 <div style="text-align:center;">
-Sheet created by Samuel Marino for Roll20.net | Last updated: <i>9/23/14</i>
+Sheet created by Samuel Marino for Roll20.net | Last updated: <i>1/2/15</i>
 <br>
 Have questions or feedback? <a href="https://app.roll20.net/forum/post/1047051/pathfinder-sheet-thread-2-golarion-boogaloo" target="_blank">This thread can help: https://app.roll20.net/forum/post/1047051/pathfinder-sheet-thread-2-golarion-boogaloo</a>
 </div>

--- a/Pathfinder-Neceros-roll-template/pathfinder-neceros-roll-template.html
+++ b/Pathfinder-Neceros-roll-template/pathfinder-neceros-roll-template.html
@@ -1,0 +1,5658 @@
+<div style="display:none;">
+<b style="color:red;font-size:150%;">Attention: </b>
+</div>
+<div class="sheet-table sheet-header">
+    <div class="sheet-table-row">
+        <div class="sheet-table-data sheet-center"><img src="http://paizo.com/image/content/Logos/PathfinderRPGLogo_500.jpeg" style="max-height: 40px;" alt="Pathfinder RPG Character Sheet" /></div>
+        <div class="sheet-table-data sheet-center sheet-label"><input title="@{character_name}" type="text" name="attr_character_name" placeholder="Character Name"/><br>Character Name</div>
+        <div class="sheet-table-data sheet-center sheet-label"><input title="@{player-name}" type="text" name="attr_player-name" placeholder="Player Name"/><br>Player Name</div>
+        <div class="sheet-table-data sheet-center sheet-label"><input title="@{race}" type="text" name="attr_race" placeholder="Race"/><br>Race</div>
+    </div>
+</div>
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab1" value="1" title="Core" checked="checked"/>
+<span class="sheet-tab sheet-tab1">Core</span>
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab2" value="2" title="Classes"/>
+<span class="sheet-tab sheet-tab2">Classes</span>
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab3" value="3" title="Defenses"/>
+<span class="sheet-tab sheet-tab3">Defenses</span>
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab4" value="4" title="Attacks"/>
+<span class="sheet-tab sheet-tab4">Attacks</span>
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab5" value="5" title="Skills"/>
+<span class="sheet-tab sheet-tab5">Skills</span>
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab6" value="6" title="Feats"/>
+<span class="sheet-tab sheet-tab6">Feats</span>
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab7" value="7" title="Items"/>
+<span class="sheet-tab sheet-tab7">Items</span>
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab8" value="8" title="Spells"/>
+<span class="sheet-tab sheet-tab8">Spells</span>
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab9" value="9" title="Details"/>
+<span class="sheet-tab sheet-tab9">Details</span>
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab99" value="99" title="Show All"/>
+<span class="sheet-tab sheet-tab99">Show All</span>
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab10" value="10" title="NPC"/>
+<span class="sheet-tab sheet-tab10">NPC</span>
+<div class="sheet-section sheet-section-core">
+    <div>
+		<b>Ability Scores&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{ability-scores-show}" name="attr_ability-scores-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+            <span class="sheet-table-name">Ability Scores</span>
+    		<div class="sheet-table-row">
+				<span class="sheet-table-header">Ability</span>
+				<span class="sheet-table-header">Total</span>
+				<span class="sheet-table-header">Mod</span>
+				<span class="sheet-table-header">|</span>
+				<span class="sheet-table-header">Base</span>
+				<span class="sheet-table-header">|</span>
+				<span class="sheet-table-header">Enhance</span>
+				<span class="sheet-table-header">Misc</span>
+				<span class="sheet-table-header">Temp</span>
+				<span class="sheet-table-header">|</span>
+				<span class="sheet-table-header">Damage</span>
+				<span class="sheet-table-header">Penalty</span>
+				<span class="sheet-table-header">Drain</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|STR-Check}" type="roll" name="roll_STR-Check" value="@{character_name}'s STR Check: [[1d20 + @{STR-mod}]]">STR</button></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR}" type="number" name="attr_STR" value="(@{STR-base} + @{STR-enhance} + @{STR-misc} + @{STR-drain})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-mod}" type="number" name="attr_STR-mod" value="((floor(@{STR}/2)-5) + floor(@{STR-temp}/2) - (floor(abs(@{STR-damage})/2)) - (floor(abs(@{STR-penalty})/2)))" disabled></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-base}" type="number" name="attr_STR-base" value="10"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-enhance}" type="number" name="attr_STR-enhance" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-misc}" type="number" name="attr_STR-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-temp}" type="number" name="attr_STR-temp" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-damage}" type="number" name="attr_STR-damage" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-penalty}" type="number" name="attr_STR-penalty" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-drain}" type="number" name="attr_STR-drain" value="0" max="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|DEX-Check}" type="roll" name="roll_DEX-Check" value="@{character_name}'s DEX Check: [[1d20 + @{DEX-mod}]]">DEX</button></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX}" type="number" name="attr_DEX" value="(@{DEX-base} + @{DEX-enhance} + @{DEX-misc} + @{DEX-drain})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-mod}" type="number" name="attr_DEX-mod" value="((floor(@{DEX}/2)-5) + floor(@{DEX-temp}/2) - (floor(abs(@{DEX-damage})/2)) - (floor(abs(@{DEX-penalty})/2)))" disabled></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-base}" type="number" name="attr_DEX-base" value="10"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-enhance}" type="number" name="attr_DEX-enhance" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-misc}" type="number" name="attr_DEX-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-temp}" type="number" name="attr_DEX-temp" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-damage}" type="number" name="attr_DEX-damage" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-penalty}" type="number" name="attr_DEX-penalty" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-drain}" type="number" name="attr_DEX-drain" value="0" max="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|CON-Check}" type="roll" name="roll_CON-Check" value="@{character_name}'s CON Check: [[1d20 + @{CON-mod}]]">CON</button></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON}" type="number" name="attr_CON" value="(@{CON-base} + @{CON-enhance} + @{CON-misc} + @{CON-drain})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-mod}" type="number" name="attr_CON-mod" value="((floor(@{CON}/2)-5) + floor(@{CON-temp}/2) - (floor(abs(@{CON-damage})/2)) - (floor(abs(@{CON-penalty})/2)))" disabled></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-base}" type="number" name="attr_CON-base" value="10"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-enhance}" type="number" name="attr_CON-enhance" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-misc}" type="number" name="attr_CON-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-temp}" type="number" name="attr_CON-temp" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-damage}" type="number" name="attr_CON-damage" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-penalty}" type="number" name="attr_CON-penalty" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-drain}" type="number" name="attr_CON-drain" value="0" max="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|INT-Check}" type="roll" name="roll_INT-Check" value="@{character_name}'s INT Check: [[1d20 + @{INT-mod}]]">INT</button></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT}" type="number" name="attr_INT" value="(@{INT-base} + @{INT-enhance} + @{INT-misc} + @{INT-drain})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT-mod}" type="number" name="attr_INT-mod" value="((floor(@{INT}/2)-5) + floor(@{INT-temp}/2) - (floor(abs(@{INT-damage})/2)) - (floor(abs(@{INT-penalty})/2)))" disabled></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT-base}" type="number" name="attr_INT-base" value="10"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT-enhance}" type="number" name="attr_INT-enhance" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT-misc}" type="number" name="attr_INT-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT-temp}" type="number" name="attr_INT-temp" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT-damage}" type="number" name="attr_INT-damage" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT-penalty}" type="number" name="attr_INT-penalty" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT-drain}" type="number" name="attr_INT-drain" value="0" max="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|WIS-Check}" type="roll" name="roll_WIS-Check" value="@{character_name}'s WIS Check: [[1d20 + @{WIS-mod}]]">WIS</button></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS}" type="number" name="attr_WIS" value="(@{WIS-base} + @{WIS-enhance} + @{WIS-misc} + @{WIS-drain})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-mod}" type="number" name="attr_WIS-mod" value="((floor(@{WIS}/2)-5) + floor(@{WIS-temp}/2) - (floor(abs(@{WIS-damage})/2)) - (floor(abs(@{WIS-penalty})/2)))" disabled></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-base}" type="number" name="attr_WIS-base" value="10"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-enhance}" type="number" name="attr_WIS-enhance" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-misc}" type="number" name="attr_WIS-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-temp}" type="number" name="attr_WIS-temp" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-damage}" type="number" name="attr_WIS-damage" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-penalty}" type="number" name="attr_WIS-penalty" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-drain}" type="number" name="attr_WIS-drain" value="0" max="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|CHA-Check}" type="roll" name="roll_CHA-Check" value="@{character_name}'s CHA Check: [[1d20 + @{CHA-mod}]]">CHA</button></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA}" type="number" name="attr_CHA" value="(@{CHA-base} + @{CHA-enhance} + @{CHA-misc} + @{CHA-drain})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-mod}" type="number" name="attr_CHA-mod" value="((floor(@{CHA}/2)-5) + floor(@{CHA-temp}/2) - (floor(abs(@{CHA-damage})/2)) - (floor(abs(@{CHA-penalty})/2)))" disabled></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-base}" type="number" name="attr_CHA-base" value="10"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-enhance}" type="number" name="attr_CHA-enhance" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-misc}" type="number" name="attr_CHA-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-temp}" type="number" name="attr_CHA-temp" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-damage}" type="number" name="attr_CHA-damage" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-penalty}" type="number" name="attr_CHA-penalty" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-drain}" type="number" name="attr_CHA-drain" value="0" max="0"></span>
+			</div>
+		</div>
+		<br>
+	</div>
+ 	<div>
+		<b>Health and Wounds&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{health-and-wounds-show}" name="attr_health-and-wounds-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Health and Wounds</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">Current HP</span>
+				<span class="sheet-table-header">/</span>
+				<span class="sheet-table-header">Max HP</span>
+				<span class="sheet-table-header">Temp HP</span>
+				<span class="sheet-table-header">Non-lethal Damage</span>
+				<span class="sheet-table-header">Max HP Formula</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" title="@{HP}" name="attr_HP" value="0"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>/</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{HP|max}" type="number" name="attr_HP_max" value="@{HP-formula}" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" title="@{HP-temp}" name="attr_HP-temp" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" title="@{non-lethal-damage}" name="attr_non-lethal-damage" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{HP-formula}" type="text" name="attr_HP-formula" value="(@{CON-mod} * @{level}) + @{total-hp}"></span>
+			</div>
+		</div>
+		<br>
+	</div>
+ 	<div>
+		<b>Initiative and Speeds&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{initiative-and-speeds-show}" name="attr_initiative-and-speeds-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<div class="sheet-table-row" style="vertical-align:top;">
+				<div class="sheet-table-data sheet-center">
+					<div class="sheet-table">
+						<span class="sheet-table-name">Initiative</span>
+						<div class="sheet-table-row">
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">Total</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">DEX</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">Trait</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">Misc</span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center" style="width:5%;"><button title="%{selected|Roll-for-initiative}" type="roll" name="roll_Roll-for-initiative" value="@{character_name}'s Initiative result: [[((1d20 + @{init}) + (0.01 * @{init})) &amp;{tracker}]]"></button></span>
+							<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" title="@{init}" name="attr_init" value="(@{DEX-mod} + @{init-misc} + @{init-trait})" disabled></span>
+							<span class="sheet-table-data sheet-center">=</span>
+							<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" title="@{DEX-mod}" name="attr_init-DEX" value="@{DEX-mod}" disabled></span>
+							<span class="sheet-table-data sheet-center">+</span>
+							<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" title="@{init-trait}" name="attr_init-trait" value="0" min="0"></span>
+							<span class="sheet-table-data sheet-center">+</span>
+							<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" title="@{init-misc}" name="attr_init-misc" value="0" min="0"></span>
+						</div>
+					</div>
+				</div>
+				<div class="sheet-table-data sheet-center">
+					&nbsp;
+				</div>
+				<div class="sheet-table-data sheet-center">
+					<div class="sheet-table">
+						<span class="sheet-table-name">Speeds</span>
+						<div class="sheet-table-row">
+							<span class="sheet-table-header">Base</span>
+							<span class="sheet-table-header">Fly</span>
+							<span class="sheet-table-header">Swim</span>
+							<span class="sheet-table-header">Climb</span>
+							<span class="sheet-table-header">Misc</span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{speed-base}" type="number" name="attr_speed-base" value="0" step="5"></span>
+							<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{speed-fly}" type="number" name="attr_speed-fly" value="0" step="5"></span>
+							<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{speed-swim}" type="number" name="attr_speed-swim" value="0" step="5"></span>
+							<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{speed-climb}" type="number" name="attr_speed-climb" value="0" step="5"></span>
+							<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{speed-misc}" type="number" name="attr_speed-misc" value="0" step="5"></span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<br>
+	</div>
+ 	<div>
+		<b>Experience and Hero Points&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{experience-and-hero-points-show}" name="attr_experience-and-hero-points-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Experience and Hero Points</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">Current Experience</span>
+				<span class="sheet-table-header">/</span>
+				<span class="sheet-table-header">Next Level</span>
+				<span class="sheet-table-header">|</span>
+				<span class="sheet-table-header">Prestige Points</span>
+				<span class="sheet-table-header">/</span>
+				<span class="sheet-table-header">Fame</span>
+				<span class="sheet-table-header">|</span>
+				<span class="sheet-table-header">Hero Points</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{experience}" type="number" name="attr_experience" placeholder="Current Experience"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>/</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{experience|max}" type="number" name="attr_experience_max" placeholder="Next Level"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{prestige}" type="number" name="attr_prestige" placeholder="Prestige Points"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>/</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{fame}" type="number" name="attr_fame" placeholder="Fame"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{hero-points}" type="number" name="attr_hero-points" placeholder="Hero Points"></span>
+			</div>
+		</div>
+	</div>
+</div>
+<div class="sheet-section sheet-section-class">
+ 	<div>
+		<b>Class Information&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{class-info-show}" name="attr_class-info-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Class Information</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">#</span>
+				<span class="sheet-table-header">HP</span>
+				<span class="sheet-table-header">FC HP</span>
+				<span class="sheet-table-header">Class Name</span>
+				<span class="sheet-table-header">BAB</span>
+				<span class="sheet-table-header">Skills/lvl</span>
+				<span class="sheet-table-header">FC Skill</span>
+				<span class="sheet-table-header">Fort</span>
+				<span class="sheet-table-header">Ref</span>
+				<span class="sheet-table-header">Will</span>
+				<span class="sheet-table-header">Levels</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><b>0.</b></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-0-hp}" type="number" name="attr_class-0-hp" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-0-fchp}" type="number" name="attr_class-0-fchp" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-0-name}" type="text" name="attr_class-0-name" placeholder="Class Name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-0-bab}" type="number" name="attr_class-0-bab" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-0-skill}" type="number" name="attr_class-0-skill" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-0-fcskill}" type="number" name="attr_class-0-fcskill" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-0-Fort}" type="number" name="attr_class-0-Fort" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-0-Ref}" type="number" name="attr_class-0-Ref" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-0-Will}" type="number" name="attr_class-0-Will" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-0-level}" type="number" name="attr_class-0-level" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><b>1.</b></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-1-hp}" type="number" name="attr_class-1-hp" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-1-fchp}" type="number" name="attr_class-1-fchp" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-1-name}" type="text" name="attr_class-1-name" placeholder="Class Name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-1-bab}" type="number" name="attr_class-1-bab" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-1-skill}" type="number" name="attr_class-1-skill" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-1-fcskill}" type="number" name="attr_class-1-fcskill" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-1-Fort}" type="number" name="attr_class-1-Fort" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-1-Ref}" type="number" name="attr_class-1-Ref" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-1-Will}" type="number" name="attr_class-1-Will" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-1-level}" type="number" name="attr_class-1-level" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><b>2.</b></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-2-hp}" type="number" name="attr_class-2-hp" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-2-fchp}" type="number" name="attr_class-2-fchp" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-2-name}" type="text" name="attr_class-2-name" placeholder="Class Name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-2-bab}" type="number" name="attr_class-2-bab" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-2-skill}" type="number" name="attr_class-2-skill" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-2-fcskill}" type="number" name="attr_class-2-fcskill" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-2-Fort}" type="number" name="attr_class-2-Fort" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-2-Ref}" type="number" name="attr_class-2-Ref" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-2-Will}" type="number" name="attr_class-2-Will" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-2-level}" type="number" name="attr_class-2-level" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><b>3.</b></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-3-hp}" type="number" name="attr_class-3-hp" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-3-fchp}" type="number" name="attr_class-3-fchp" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-3-name}" type="text" name="attr_class-3-name" placeholder="Class Name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-3-bab}" type="number" name="attr_class-3-bab" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-3-skill}" type="number" name="attr_class-3-skill" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-3-fcskill}" type="number" name="attr_class-3-fcskill" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-3-Fort}" type="number" name="attr_class-3-Fort" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-3-Ref}" type="number" name="attr_class-3-Ref" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-3-Will}" type="number" name="attr_class-3-Will" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-3-level}" type="number" name="attr_class-3-level" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><b>4.</b></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-4-hp}" type="number" name="attr_class-4-hp" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-4-fchp}" type="number" name="attr_class-4-fchp" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-4-name}" type="text" name="attr_class-4-name" placeholder="Class Name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-4-bab}" type="number" name="attr_class-4-bab" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-4-skill}" type="number" name="attr_class-4-skill" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-4-fcskill}" type="number" name="attr_class-4-fcskill" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-4-Fort}" type="number" name="attr_class-4-Fort" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-4-Ref}" type="number" name="attr_class-4-Ref" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-4-Will}" type="number" name="attr_class-4-Will" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-4-level}" type="number" name="attr_class-4-level" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><b>Totals</b></span>
+				<span class="sheet-table-data sheet-center"><input title="@{total-hp}" type="number" name="attr_total-hp" value="(@{class-0-hp} + @{class-1-hp} + @{class-2-hp} + @{class-3-hp} + @{class-4-hp} + @{class-0-fchp} + @{class-1-fchp} + @{class-2-fchp} + @{class-3-fchp} + @{class-4-fchp})" disabled></span>
+				<span class="sheet-table-data sheet-center sheet-label">FC:</span>
+				<span class="sheet-table-data sheet-center"><input title="@{class-favored}" type="text" name="attr_class-favored" placeholder="Favored Class(es)"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + @{class-1-bab} + @{class-2-bab} + @{class-3-bab} + @{class-4-bab})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{total-skill}" type="number" name="attr_total-skill" value="@{max-skill-ranks-formula}" disabled></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{total-Fort}" type="number" name="attr_total-Fort" value="(@{class-0-Fort} + @{class-1-Fort} + @{class-2-Fort} + @{class-3-Fort} + @{class-4-Fort})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{total-Ref}" type="number" name="attr_total-Ref" value="(@{class-0-Ref} + @{class-1-Ref} + @{class-2-Ref} + @{class-3-Ref} + @{class-4-Ref})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{total-Will}" type="number" name="attr_total-Will" value="(@{class-0-Will} + @{class-1-Will} + @{class-2-Will} + @{class-3-Will} + @{class-4-Will})" disabled></span>
+				<span class="sheet-table-data sheet-center"><input title="@{level}" type="number" name="attr_level" value="(@{class-0-level} + @{class-1-level} + @{class-2-level} + @{class-3-level} + @{class-4-level})" disabled></span>
+			</div>
+		</div>
+		<br>
+	</div>
+ 	<div>
+		<b>Class Features and Abilities&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{class-features-show}" name="attr_class-features-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Class Ability Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_0_Display" title="%{selected|repeating_class-ability_0_Display}" value="/em is activating their @{repeating_class-ability_0_class-number} ability, @{repeating_class-ability_0_name}&#x00A;@{repeating_class-ability_0_short-description}&#x00A;@{repeating_class-ability_0_name} uses remaining: [[@{repeating_class-ability_0_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_1_Display" title="%{selected|repeating_class-ability_1_Display}" value="/em is activating their @{repeating_class-ability_1_class-number} ability, @{repeating_class-ability_1_name}&#x00A;@{repeating_class-ability_1_short-description}&#x00A;@{repeating_class-ability_1_name} uses remaining: [[@{repeating_class-ability_1_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_2_Display" title="%{selected|repeating_class-ability_2_Display}" value="/em is activating their @{repeating_class-ability_2_class-number} ability, @{repeating_class-ability_2_name}&#x00A;@{repeating_class-ability_2_short-description}&#x00A;@{repeating_class-ability_2_name} uses remaining: [[@{repeating_class-ability_2_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_3_Display" title="%{selected|repeating_class-ability_3_Display}" value="/em is activating their @{repeating_class-ability_3_class-number} ability, @{repeating_class-ability_3_name}&#x00A;@{repeating_class-ability_3_short-description}&#x00A;@{repeating_class-ability_3_name} uses remaining: [[@{repeating_class-ability_3_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_4_Display" title="%{selected|repeating_class-ability_4_Display}" value="/em is activating their @{repeating_class-ability_4_class-number} ability, @{repeating_class-ability_4_name}&#x00A;@{repeating_class-ability_4_short-description}&#x00A;@{repeating_class-ability_4_name} uses remaining: [[@{repeating_class-ability_4_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_5_Display" title="%{selected|repeating_class-ability_5_Display}" value="/em is activating their @{repeating_class-ability_5_class-number} ability, @{repeating_class-ability_5_name}&#x00A;@{repeating_class-ability_5_short-description}&#x00A;@{repeating_class-ability_5_name} uses remaining: [[@{repeating_class-ability_5_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_6_Display" title="%{selected|repeating_class-ability_6_Display}" value="/em is activating their @{repeating_class-ability_6_class-number} ability, @{repeating_class-ability_6_name}&#x00A;@{repeating_class-ability_6_short-description}&#x00A;@{repeating_class-ability_6_name} uses remaining: [[@{repeating_class-ability_6_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_7_Display" title="%{selected|repeating_class-ability_7_Display}" value="/em is activating their @{repeating_class-ability_7_class-number} ability, @{repeating_class-ability_7_name}&#x00A;@{repeating_class-ability_7_short-description}&#x00A;@{repeating_class-ability_7_name} uses remaining: [[@{repeating_class-ability_7_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_8_Display" title="%{selected|repeating_class-ability_8_Display}" value="/em is activating their @{repeating_class-ability_8_class-number} ability, @{repeating_class-ability_8_name}&#x00A;@{repeating_class-ability_8_short-description}&#x00A;@{repeating_class-ability_8_name} uses remaining: [[@{repeating_class-ability_8_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_9_Display" title="%{selected|repeating_class-ability_9_Display}" value="/em is activating their @{repeating_class-ability_9_class-number} ability, @{repeating_class-ability_9_name}&#x00A;@{repeating_class-ability_9_short-description}&#x00A;@{repeating_class-ability_9_name} uses remaining: [[@{repeating_class-ability_9_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_10_Display" title="%{selected|repeating_class-ability_10_Display}" value="/em is activating their @{repeating_class-ability_10_class-number} ability, @{repeating_class-ability_10_name}&#x00A;@{repeating_class-ability_10_short-description}&#x00A;@{repeating_class-ability_10_name} uses remaining: [[@{repeating_class-ability_10_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_11_Display" title="%{selected|repeating_class-ability_11_Display}" value="/em is activating their @{repeating_class-ability_11_class-number} ability, @{repeating_class-ability_11_name}&#x00A;@{repeating_class-ability_11_short-description}&#x00A;@{repeating_class-ability_11_name} uses remaining: [[@{repeating_class-ability_11_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_12_Display" title="%{selected|repeating_class-ability_12_Display}" value="/em is activating their @{repeating_class-ability_12_class-number} ability, @{repeating_class-ability_12_name}&#x00A;@{repeating_class-ability_12_short-description}&#x00A;@{repeating_class-ability_12_name} uses remaining: [[@{repeating_class-ability_12_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_13_Display" title="%{selected|repeating_class-ability_13_Display}" value="/em is activating their @{repeating_class-ability_13_class-number} ability, @{repeating_class-ability_13_name}&#x00A;@{repeating_class-ability_13_short-description}&#x00A;@{repeating_class-ability_13_name} uses remaining: [[@{repeating_class-ability_13_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_14_Display" title="%{selected|repeating_class-ability_14_Display}" value="/em is activating their @{repeating_class-ability_14_class-number} ability, @{repeating_class-ability_14_name}&#x00A;@{repeating_class-ability_14_short-description}&#x00A;@{repeating_class-ability_14_name} uses remaining: [[@{repeating_class-ability_14_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_15_Display" title="%{selected|repeating_class-ability_15_Display}" value="/em is activating their @{repeating_class-ability_15_class-number} ability, @{repeating_class-ability_15_name}&#x00A;@{repeating_class-ability_15_short-description}&#x00A;@{repeating_class-ability_15_name} uses remaining: [[@{repeating_class-ability_15_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_16_Display" title="%{selected|repeating_class-ability_16_Display}" value="/em is activating their @{repeating_class-ability_16_class-number} ability, @{repeating_class-ability_16_name}&#x00A;@{repeating_class-ability_16_short-description}&#x00A;@{repeating_class-ability_16_name} uses remaining: [[@{repeating_class-ability_16_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_17_Display" title="%{selected|repeating_class-ability_17_Display}" value="/em is activating their @{repeating_class-ability_17_class-number} ability, @{repeating_class-ability_17_name}&#x00A;@{repeating_class-ability_17_short-description}&#x00A;@{repeating_class-ability_17_name} uses remaining: [[@{repeating_class-ability_17_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_18_Display" title="%{selected|repeating_class-ability_18_Display}" value="/em is activating their @{repeating_class-ability_18_class-number} ability, @{repeating_class-ability_18_name}&#x00A;@{repeating_class-ability_18_short-description}&#x00A;@{repeating_class-ability_18_name} uses remaining: [[@{repeating_class-ability_18_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_19_Display" title="%{selected|repeating_class-ability_19_Display}" value="/em is activating their @{repeating_class-ability_19_class-number} ability, @{repeating_class-ability_19_name}&#x00A;@{repeating_class-ability_19_short-description}&#x00A;@{repeating_class-ability_19_name} uses remaining: [[@{repeating_class-ability_19_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_20_Display" title="%{selected|repeating_class-ability_20_Display}" value="/em is activating their @{repeating_class-ability_20_class-number} ability, @{repeating_class-ability_20_name}&#x00A;@{repeating_class-ability_20_short-description}&#x00A;@{repeating_class-ability_20_name} uses remaining: [[@{repeating_class-ability_20_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_21_Display" title="%{selected|repeating_class-ability_21_Display}" value="/em is activating their @{repeating_class-ability_21_class-number} ability, @{repeating_class-ability_21_name}&#x00A;@{repeating_class-ability_21_short-description}&#x00A;@{repeating_class-ability_21_name} uses remaining: [[@{repeating_class-ability_21_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_22_Display" title="%{selected|repeating_class-ability_22_Display}" value="/em is activating their @{repeating_class-ability_22_class-number} ability, @{repeating_class-ability_22_name}&#x00A;@{repeating_class-ability_22_short-description}&#x00A;@{repeating_class-ability_22_name} uses remaining: [[@{repeating_class-ability_22_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_23_Display" title="%{selected|repeating_class-ability_23_Display}" value="/em is activating their @{repeating_class-ability_23_class-number} ability, @{repeating_class-ability_23_name}&#x00A;@{repeating_class-ability_23_short-description}&#x00A;@{repeating_class-ability_23_name} uses remaining: [[@{repeating_class-ability_23_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_24_Display" title="%{selected|repeating_class-ability_24_Display}" value="/em is activating their @{repeating_class-ability_24_class-number} ability, @{repeating_class-ability_24_name}&#x00A;@{repeating_class-ability_24_short-description}&#x00A;@{repeating_class-ability_24_name} uses remaining: [[@{repeating_class-ability_24_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_25_Display" title="%{selected|repeating_class-ability_25_Display}" value="/em is activating their @{repeating_class-ability_25_class-number} ability, @{repeating_class-ability_25_name}&#x00A;@{repeating_class-ability_25_short-description}&#x00A;@{repeating_class-ability_25_name} uses remaining: [[@{repeating_class-ability_25_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_class-ability_26_Display" title="%{selected|repeating_class-ability_26_Display}" value="/em is activating their @{repeating_class-ability_26_class-number} ability, @{repeating_class-ability_26_name}&#x00A;@{repeating_class-ability_26_short-description}&#x00A;@{repeating_class-ability_26_name} uses remaining: [[@{repeating_class-ability_26_used}-1]]"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Class Features and Abilities</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header" style="width:5%;"></span>
+				<span class="sheet-table-header" style="width:10%;">Class #</span>
+				<span class="sheet-table-header" style="width:15%;">Class</span>
+				<span class="sheet-table-header" style="width:15%;">Name</span>
+				<span class="sheet-table-header" style="width:28%;">Short Description</span>
+				<span class="sheet-table-header" style="width:5%;">Uses</span>
+				<span class="sheet-table-header" style="width:2%;vertical-align:bottom;font-size:150%;">/</span>
+				<span class="sheet-table-header" style="width:5%;">Max</span>
+				<span class="sheet-table-header" style="width:15%;">Max Calculation</span>
+			</div>
+		</div>
+		<div class="sheet-table sheet-sect">
+			<fieldset class="repeating_class-ability">  
+				<span class="sheet-table-data sheet-center" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+				<span class="sheet-table-data sheet-center" style="width:10%;">
+					<select title="@{repeating_class-ability_X_class-number}" name="attr_class-number">
+						<option value="" selected>Select Class</option>
+						<option value="@{class-0-name}">0</option>
+						<option value="@{class-1-name}">1</option>
+						<option value="@{class-2-name}">2</option>
+						<option value="@{class-3-name}">3</option>
+						<option value="@{class-4-name}">4</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center" style="width:15%;"><input title="@{repeating_class-ability_X_class-name}" type="text" name="attr_class-name" value="@{class-number}" disabled></span>
+				<span class="sheet-table-data sheet-center" style="width:15%;"><input title="@{repeating_class-ability_X_name}" type="text" name="attr_name" placeholder="Ability Name"></span>
+				<span class="sheet-table-data sheet-center" style="width:28%;"><input title="@{repeating_class-ability_X_short-description}" type="text" name="attr_short-description" placeholder="Short Description"></span>
+				<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_class-ability_X_used}" type="number" name="attr_used" value="0"></span>
+				<span class="sheet-table-data sheet-center" style="width:2%;vertical-align:middle;font-size:150%;">/</span>
+				<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_class-ability_X_used|max}" type="number" name="attr_used_max" value="@{max-calculation}" disabled></span>
+				<span class="sheet-table-data sheet-center" style="width:15%;"><input title="@{repeating_class-ability_X_max-calculation}" type="text" name="attr_max-calculation" value="0"></span>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_class-ability_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_class-ability_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_class-ability_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_class-ability_X_macro-text}" name="attr_macro-text">/em is activating their @{class-number} ability, @{name}&#x00A;@{short-description}&#x00A;@{name} uses remaining: [[@{used}-1]]</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+</div>
+<div class="sheet-section sheet-section-defenses">
+ 	<div>
+		<b>Defense Values&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{defense-values-show}" name="attr_defense-values-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Defense Values</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">Armor Class</span>
+				<span class="sheet-table-header">Total</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Armor</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Shield</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">DEX</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Size</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Dodge</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Natural</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Deflect</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Misc</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Temp</span>
+				<span class="sheet-table-header">|</span>    
+				<span class="sheet-table-header">Penalty</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name">AC</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC}" type="number" name="attr_AC" value="(10 + @{AC-armor} + @{AC-shield} + @{AC-DEX} + @{size} + @{AC-dodge} + @{AC-natural} + @{AC-deflect} + @{AC-misc} + @{AC-temp} + @{AC-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center" style="width:48px;">= 10 +</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{armor-acbonus}" type="number" name="attr_AC-armor" value="(@{armor-acbonus} * @{armor-equipped})" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{shield-acbonus}" type="number" name="attr_AC-shield" value="(@{shield-acbonus} * @{shield-equipped})" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-DEX}" type="number" name="attr_AC-DEX" value="(((@{DEX-mod} + @{max-dex-source}) - abs(@{DEX-mod} - @{max-dex-source})) / 2)" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{size}" type="number" name="attr_AC-size" value="@{size}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-dodge}" type="number" name="attr_AC-dodge" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-natural}" type="number" name="attr_AC-natural" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-deflect}" type="number" name="attr_AC-deflect" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-misc}" type="number" name="attr_AC-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-temp}" type="number" name="attr_AC-temp" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-penalty}" type="number" name="attr_AC-penalty" value="0" max="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="width:90px;">Touch</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Touch}" type="number" name="attr_Touch" value="(10 + @{AC-DEX} + @{size} + @{AC-dodge} + @{AC-deflect} + @{AC-misc} + @{AC-temp} + @{AC-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center" style="width:48px;">= 10 +</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" value="0" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" value="0" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-DEX}" type="number" name="attr_Touch-DEX" value="@{AC-DEX}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{size}" type="number" name="attr_AC-size" value="@{size}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-dodge}" type="number" name="attr_AC-dodge" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" value="0" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-deflect}" type="number" name="attr_AC-deflect" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-misc}" type="number" name="attr_AC-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-temp}" type="number" name="attr_AC-temp" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-penalty}" type="number" name="attr_AC-penalty" value="0" max="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name">Flat-Footed</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Flat-Footed}" type="number" name="attr_Flat-Footed" value="(10 + @{AC-armor} + @{AC-shield} + @{FF-DEX} + @{size} + @{AC-natural} + @{AC-deflect} + @{AC-misc} + @{AC-temp} + @{AC-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center" style="width:48px;">= 10 +</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{armor-acbonus}" type="number" name="attr_AC-armor" value="(@{armor-acbonus} * @{armor-equipped})" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{shield-acbonus}" type="number" name="attr_AC-shield" value="(@{shield-acbonus} * @{shield-equipped})" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{attr_FF-DEX}" type="number" name="attr_FF-DEX" value="((@{AC-DEX} - abs(@{AC-DEX}))/2)" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{size}" type="number" name="attr_AC-size" value="@{size}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" value="0" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-natural}" type="number" name="attr_AC-natural" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-deflect}" type="number" name="attr_AC-deflect" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-misc}" type="number" name="attr_AC-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-temp}" type="number" name="attr_AC-temp" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-penalty}" type="number" name="attr_AC-penalty" value="0" max="0"></span>
+			</div>	
+			<div class="sheet-table-row">
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Total</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">BAB</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">STR</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">DEX</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Size</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Dodge</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Deflect</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Misc</span>
+				<span class="sheet-table-header"></span>    
+				<span class="sheet-table-header">Temp</span>
+				<span class="sheet-table-header">|</span>
+				<span class="sheet-table-header">Penalty</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name">CMD</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CMD}" type="number" name="attr_CMD" value="(10 + @{bab} + @{STR-mod} + @{DEX-mod} + @{CMD-size} + @{AC-dodge} + @{AC-deflect} + @{CMD-misc} + @{CMD-temp} + @{AC-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center" style="width:48px;">= 10 +</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{bab}" type="number" name="attr_CMD-bab" value="@{bab}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-mod}" type="number" name="attr_CMD-STR" value="@{STR-mod}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-mod}" type="number" name="attr_CMD-DEX" value="@{DEX-mod}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CMD-size}" type="number" name="attr_CMD-size" value="(-1 * @{size})" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-dodge}" type="number" name="attr_AC-dodge" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-deflect}" type="number" name="attr_AC-deflect" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CMD-misc}" type="number" name="attr_CMD-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CMD-temp}" type="number" name="attr_CMD-temp" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-penalty}" type="number" name="attr_AC-penalty" value="0" max="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name">FF CMD</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{FF-CMD}" type="number" name="attr_FF-CMD" value="(10 + @{bab} + @{STR-mod} + @{FF-DEX} + @{CMD-size} + @{AC-deflect} + @{CMD-misc} + @{CMD-temp} + @{AC-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center" style="width:48px;">= 10 +</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{bab}" type="number" name="attr_CMD-bab" value="@{bab}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-mod}" type="number" name="attr_CMD-STR" value="@{STR-mod}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{attr_FF-DEX}" type="number" name="attr_FF-DEX" value="((@{AC-DEX} - abs(@{AC-DEX}))/2)" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CMD-size}" type="number" name="attr_CMD-size" value="(-1 * @{size})" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" type="number" name="attr_FF-CMD-dodge" value="0" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-deflect}" type="number" name="attr_AC-deflect" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CMD-misc}" type="number" name="attr_CMD-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CMD-temp}" type="number" name="attr_CMD-temp" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{AC-penalty}" type="number" name="attr_AC-penalty" value="0" max="0"></span>
+			</div>
+		</div>
+		<br>
+	</div>
+ 	<div>
+		<b>Special Defenses&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{special-defenses-show}" name="attr_special-defenses-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Special Defenses</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header sheet-center">DR</span>
+				<span class="sheet-table-header sheet-center">Resistances</span>
+				<span class="sheet-table-header sheet-center">Immunities</span>
+				<span class="sheet-table-header sheet-center">Weaknesses</span>
+				<span class="sheet-table-header sheet-center">SR</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><input title="@{DR}" type="text" name="attr_DR" placeholder="Damage resistances"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{resistances}" type="text" name="attr_resistances" placeholder="Resistances"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{immunities}" type="text" name="attr_immunities" placeholder="Immunities"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{weaknesses}" type="text" name="attr_weaknesses" placeholder="Weaknesses"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{SR}" type="number" name="attr_SR" value="0"></span>
+			</div>
+		</div>
+		<br>
+	</div>
+ 	<div>
+		<b>Armor Penalties&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{armor-penalties-show}" name="attr_armor-penalties-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Armor Penalties</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name">Armor Check Penalty</span>
+				<span class="sheet-table-data sheet-center"><input title="@{acp}" type="number" name="attr_acp" value="(abs(@{acp-source}) * -1)" disabled></span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{acp-source}" name="attr_acp-source">
+						<option value="0">None</option>
+						<option value="((@{armor-acp} * @{armor-equipped}) + (@{shield-acp} * @{shield-equipped}))" selected>Armor & Shield</option>
+						<option value="-3">Medium Load</option>
+						<option value="-6">Heavy Load</option>
+					</select>					
+				</span>
+				<span class="sheet-table-row-name">Max DEX</span>
+				<span class="sheet-table-data sheet-center"><input title="@{max-dex}" type="number" name="attr_max-dex" value="@{max-dex-source}" disabled></span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{max-dex-source}" name="attr_max-dex-source">
+						<option value="9999" selected>None</option>
+						<option value="@{armor-max-dex}">Armor</option>
+						<option value="@{shield-max-dex}">Shield</option>
+						<option value="3">Medium Load</option>
+						<option value="1">Heavy Load</option>
+					</select>					
+				</span>
+				<span class="sheet-table-row-name"><button class="sheet-text-button" type="roll" title="%{selected|Spell-Fail-Check}" name="roll_Spell-Fail-Check" value="@{character_name}'s spell fail check&#x00A;Spell fail chance: [[@{spell-fail}]]&#37;&#x00A;/r 1d100>[[@{spell-fail}]]">Spell Fail Chance</button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{spell-fail}" type="number" name="attr_spell-fail" value="((@{armor-spell-fail} * @{armor-equipped}) + (@{shield-spell-fail} * @{shield-equipped}))" disabled>&#37;</span>
+			</div>
+		</div>
+		<br>
+	</div>
+ 	<div>
+		<b>Saving Throws&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{saves-show}" name="attr_saves-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Saving Throws</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">Save</span>
+				<span class="sheet-table-header">Total</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Base</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Ability</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Trait</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Enhancement</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Resistance</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Misc</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Temp</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" ><button class="sheet-text-button" title="%{selected|Fort-Save}" type="roll" name="roll_Fort-Save" value="@{character_name}'s Fortitude save: [[1d20 + @{Fort}]]&#x00A;Save notes: @{Save-notes}">Fort</button></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Fort}" type="number" name="attr_Fort" value="(@{total-Fort} + @{CON-mod} + @{Fort-trait} + @{Fort-enhance} + @{Fort-resist} + @{Fort-misc} + @{Fort-temp})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{total-Fort}" type="number" name="attr_Fort-base" value="@{total-Fort}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-mod}" type="number" name="attr_Fort-ability" value="@{CON-mod}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Fort-trait}" type="number" name="attr_Fort-trait" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Fort-enhance}" type="number" name="attr_Fort-enhance" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Fort-resist}" type="number" name="attr_Fort-resist" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Fort-misc}" type="number" name="attr_Fort-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Fort-temp}" type="number" name="attr_Fort-temp" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|Ref-Save}" type="roll" name="roll_Ref-Save" value="@{character_name}'s Reflex save: [[1d20 + @{Ref}]]&#x00A;Save notes: @{Save-notes}">Ref</button></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Ref}" type="number" name="attr_Ref" value="(@{total-Ref} + @{DEX-mod} + @{Ref-trait} + @{Ref-enhance} + @{Ref-resist} + @{Ref-misc} + @{Ref-temp})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{total-Ref}" type="number" name="attr_Ref-base" value="@{total-Ref}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-mod}" type="number" name="attr_Ref-ability" value="@{DEX-mod}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Ref-trait}" type="number" name="attr_Ref-trait" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Ref-enhance}" type="number" name="attr_Ref-enhance" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Ref-resist}" type="number" name="attr_Ref-resist" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Ref-misc}" type="number" name="attr_Ref-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Ref-temp}" type="number" name="attr_Ref-temp" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|Will-Save}" type="roll" name="roll_Will-Save" value="@{character_name}'s Will save: [[1d20 + @{Will}]]&#x00A;Save notes: @{Save-notes}">Will</button></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Will}" type="number" name="attr_Will" value="(@{total-Will} + @{WIS-mod} + @{Will-trait} + @{Will-enhance} + @{Will-resist} + @{Will-misc} + @{Will-temp})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{total-Will}" type="number" name="attr_Will-base" value="@{total-Will}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-mod}" type="number" name="attr_Will-ability" value="@{WIS-mod}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Will-trait}" type="number" name="attr_Will-trait" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Will-enhance}" type="number" name="attr_Will-enhance" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Will-resist}" type="number" name="attr_Will-resist" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Will-misc}" type="number" name="attr_Will-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Will-temp}" type="number" name="attr_Will-temp" value="0"></span>
+			</div>
+		</div>
+		<br>
+	</div>
+ 	<div>
+		<b>Armor and Shield&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{armor-shield-show}" name="attr_armor-shield-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Armor and Shield</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">On/Off</span>
+				<span class="sheet-table-header">Name</span>
+				<span class="sheet-table-header">AC Bonus</span>
+				<span class="sheet-table-header">Max DEX</span>
+				<span class="sheet-table-header">ACP</span>
+				<span class="sheet-table-header">Spell Fail</span>
+				<span class="sheet-table-header">Type</span>
+				<span class="sheet-table-header">Proficiency</span>
+				<span class="sheet-table-header">Weight</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><input title="@{armor-equipped}" type="checkbox" name="attr_armor-equipped" value="1" checked /></span>
+				<span class="sheet-table-data sheet-center"><input title="@{armor}" type="text" name="attr_armor" placeholder="Armor" class="sheet-detail-medium"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{armor-acbonus}" type="number" name="attr_armor-acbonus" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{armor-max-dex}" type="number" name="attr_armor-max-dex" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{armor-acp}" type="number" name="attr_armor-acp" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{armor-spell-fail}" type="number" name="attr_armor-spell-fail" value="0" min="0" max="100">&#37;</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{armor-type}" name="attr_armor-type">
+						<option value="Light">Light</option>
+						<option value="Medium">Medium</option>
+						<option value="Heavy">Heavy</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{armor-proficiency}" name="attr_armor-proficiency">
+						<option value="0">Yes</option>
+						<option value="(@{armor-equipped} * @{armor-acp})">No</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{armor-weight}" type="number" name="attr_armor-weight" step="any" min="0" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><input title="@{shield-equipped}" type="checkbox" name="attr_shield-equipped" value="1" checked /></span>
+				<span class="sheet-table-data sheet-center"><input title="@{shield}" type="text" name="attr_shield" placeholder="Shield" class="sheet-detail-medium"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{shield-acbonus}" type="number" name="attr_shield-acbonus" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{shield-max-dex}" type="number" name="attr_shield-max-dex" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{shield-acp}" type="number" name="attr_shield-acp" value="0" max="0"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{shield-spell-fail}" type="number" name="attr_shield-spell-fail" value="0" min="0" max="100">&#37;</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{shield-type}" name="attr_shield-type">
+						<option value="Shield">Shield</option>
+						<option value="Tower Shield">Tower Shield</option>
+					</select></span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{shield-proficiency}" name="attr_shield-proficiency">
+						<option value="0">Yes</option>
+						<option value="(@{shield-equipped} * @{shield-acp})">No</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{shield-weight}" type="number" name="attr_shield-weight" step="any" min="0" value="0"></span>
+			</div>
+		</div>
+		<br>
+	</div>
+ 	<div>
+		<b>Defense Notes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{defense-notes-show}" name="attr_defense-notes-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<div class="sheet-table-row">
+				<div class="sheet-table-data sheet-center">
+					<div class="sheet-table">
+						<span class="sheet-table-name">Armor Notes</span>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-left"><textarea title="@{Armor-notes}" name="attr_Armor-notes" placeholder="Put notes about context-sensitive AC bonuses here."></textarea></span>
+						</div>
+					</div>
+				</div>
+				<div class="sheet-table-data sheet-center">
+					<div class="sheet-table">
+						<span class="sheet-table-name">Save Notes</span>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-left"><textarea title="@{Save-notes}" name="attr_Save-notes" placeholder="Put notes about context-sensitive Saving Throw bonuses here."></textarea></span>
+						</div>
+					</div>
+				</div>
+				<div class="sheet-table-data sheet-center">
+					<div class="sheet-table">
+						<span class="sheet-table-name">CMD Notes</span>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-left"><textarea title="@{cmd-notes}" name="attr_cmd-notes" placeholder="Put notes about context-sensitive CMD bonuses here."></textarea></span>
+						</div>
+					</div>
+				</div>
+				<div class="sheet-table-data sheet-center">
+					<div class="sheet-table">
+						<span class="sheet-table-name">Defense Notes</span>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-left"><textarea title="@{defense-notes}" name="attr_defense-notes" placeholder="Put notes about context-sensitive defense bonuses here."></textarea></span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+<div class="sheet-section sheet-section-attacks">
+ 	<div>
+		<b>Attack and Combat Maneuver Bonuses&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{attack-bonuses-show}" name="attr_attack-bonuses-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Attack and Combat Maneuver Bonuses</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">Attack</span>
+				<span class="sheet-table-header">Total</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">BAB</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Ability</span>
+				<span class="sheet-table-header">Mod</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Size</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Misc</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Temp</span>
+				<span class="sheet-table-header">|</span>
+				<span class="sheet-table-header">Penalty</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;width:10%;"><button class="sheet-text-button" type="roll" title="%{selected|Melee-Attack-Roll}" name="roll_Melee-Attack-Roll" value="@{character_name}'s Melee Attack result: [[1d20 + @{attk-melee}]]">Melee</button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-melee}" type="number" name="attr_attk-melee" value="(@{bab} + @{attk-melee-ability} + @{size} + @{attk-melee-misc} + @{attk-melee-temp} + @{attk-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + @{class-1-bab} + @{class-2-bab} + @{class-3-bab} + @{class-4-bab})" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{attk-melee-ability}" name="attr_attk-melee-ability">
+						<option value="0">None</option>
+						<option value="@{STR-mod}" selected>STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-melee-ability-value}" type="number" name="attr_attk-melee-ability-value" value="@{attk-melee-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{size}" type="number" name="attr_attk-melee-size" value="@{size}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-melee-misc}" type="number" name="attr_attk-melee-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-melee-temp}" type="number" name="attr_attk-melee-temp" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-penalty}" type="number" name="attr_attk-penalty" value="0" max="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;width:10%;"><button class="sheet-text-button" type="roll" title="%{selected|Ranged-Attack-Roll}" name="roll_Ranged-Attack-Roll" value="@{character_name}'s Ranged Attack result: [[1d20 + @{attk-ranged}]]">Ranged</button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-ranged}" type="number" name="attr_attk-ranged" value="(@{bab} + @{attk-ranged-ability} + @{size} + @{attk-ranged-misc} + @{attk-ranged-temp} + @{attk-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + @{class-1-bab} + @{class-2-bab} + @{class-3-bab} + @{class-4-bab})" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{attk-ranged-ability}" name="attr_attk-ranged-ability">
+						<option value="0">None</option>
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}" selected>DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-ranged-ability-value}" type="number" name="attr_attk-ranged-ability-value" value="@{attk-ranged-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{size}" type="number" name="attr_attk-ranged-size" value="@{size}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-ranged-misc}" type="number" name="attr_attk-ranged-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-ranged-temp}" type="number" name="attr_attk-ranged-temp" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-penalty}" type="number" name="attr_attk-penalty" value="0" max="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;width:10%;"><button class="sheet-text-button" type="roll" title="%{selected|CMB-Check}" name="roll_CMB-Check" value="@{character_name}'s CMB check&#x00A;[[1d20 + @{CMB}]]&#x00A;CMB notes: @{cmb-notes}">CMB</button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{CMB}" type="number" name="attr_CMB" value="(@{bab} + @{attk-CMB-ability} + @{attk-CMB-size} + @{attk-CMB-misc} + @{attk-CMB-temp} + @{attk-penalty})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + @{class-1-bab} + @{class-2-bab} + @{class-3-bab} + @{class-4-bab})" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{attk-CMB-ability}" name="attr_attk-CMB-ability">
+						<option value="0">None</option>
+						<option value="@{STR-mod}" selected>STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-CMB-ability-value}" type="number" name="attr_attk-CMB-ability-value" value="@{attk-CMB-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-CMB-size}" type="number" name="attr_attk-CMB-size" value="(@{size} * -1)" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-CMB-misc}" type="number" name="attr_attk-CMB-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-CMB-temp}" type="number" name="attr_attk-CMB-temp" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-penalty}" type="number" name="attr_attk-penalty" value="0" max="0"></span>
+			</div>
+		</div>
+		<br>
+	</div>
+ 	<div>
+		<b>Attack Notes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{attack-notes-show}" name="attr_attack-notes-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<div class="sheet-table-row">
+				<div class="sheet-table-data sheet-center">
+					<div class="sheet-table">
+						<span class="sheet-table-name">Melee Attack Notes</span>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-left"><textarea title="@{melee-attack-notes}" name="attr_melee-attack-notes" placeholder="Put notes about context-sensitive Melee Attack bonuses here."></textarea></span>
+						</div>
+					</div>
+				</div>
+				<div class="sheet-table-data sheet-center">
+					<div class="sheet-table">
+						<span class="sheet-table-name">Ranged Attack Notes</span>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-left"><textarea title="@{ranged-attack-notes}" name="attr_ranged-attack-notes" placeholder="Put notes about context-sensitive Ranged Attack bonuses here."></textarea></span>
+						</div>
+					</div>
+				</div>
+				<div class="sheet-table-data sheet-center">
+					<div class="sheet-table">
+						<span class="sheet-table-name">CMB Notes</span>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-left"><textarea title="@{CMB-notes}" name="attr_CMB-notes" placeholder="Put notes about context-sensitive CMB bonuses here."></textarea></span>
+						</div>
+					</div>
+				</div>
+				<div class="sheet-table-data sheet-center">
+					<div class="sheet-table">
+						<span class="sheet-table-name">Attack Notes</span>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-left"><textarea title="@{attack-notes}" name="attr_attack-notes" placeholder="Put notes about context-sensitive Attack bonuses here."></textarea></span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+ 	<div>
+		<b>Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{attacks-show}" name="attr_attacks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Attack Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_0_Attack" title="%{selected|repeating_weapon_0_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_0_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_0_proficiency} + (((@{repeating_weapon_0_enhance} + @{repeating_weapon_0_masterwork}) + abs(@{repeating_weapon_0_enhance} - @{repeating_weapon_0_masterwork})) / 2) + @{repeating_weapon_0_attack} + @{repeating_weapon_0_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_0_crit-target}) + (@{repeating_weapon_0_proficiency} + (((@{repeating_weapon_0_enhance} + @{repeating_weapon_0_masterwork}) + abs(@{repeating_weapon_0_enhance} - @{repeating_weapon_0_masterwork})) / 2) + @{repeating_weapon_0_attack} + @{repeating_weapon_0_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_0_damage-dice-num}d@{repeating_weapon_0_damage-die} + (@{repeating_weapon_0_enhance} + @{repeating_weapon_0_damage} + @{repeating_weapon_0_damage-ability})]]&#x00A;Crit: @{repeating_weapon_0_crit-target}/x@{repeating_weapon_0_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_0_proficiency} + (((@{repeating_weapon_0_enhance} + @{repeating_weapon_0_masterwork}) + abs(@{repeating_weapon_0_enhance} - @{repeating_weapon_0_masterwork})) / 2) + @{repeating_weapon_0_attack} + @{repeating_weapon_0_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_0_damage-dice-num} * (@{repeating_weapon_0_crit-multiplier} - 1))d@{repeating_weapon_0_damage-die} + ((@{repeating_weapon_0_enhance} + @{repeating_weapon_0_damage} + @{repeating_weapon_0_damage-ability}) * (@{repeating_weapon_0_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_0_type}&#x00A;Notes: @{repeating_weapon_0_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_1_Attack" title="%{selected|repeating_weapon_1_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_1_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_1_proficiency} + (((@{repeating_weapon_1_enhance} + @{repeating_weapon_1_masterwork}) + abs(@{repeating_weapon_1_enhance} - @{repeating_weapon_1_masterwork})) / 2) + @{repeating_weapon_1_attack} + @{repeating_weapon_1_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_1_crit-target}) + (@{repeating_weapon_1_proficiency} + (((@{repeating_weapon_1_enhance} + @{repeating_weapon_1_masterwork}) + abs(@{repeating_weapon_1_enhance} - @{repeating_weapon_1_masterwork})) / 2) + @{repeating_weapon_1_attack} + @{repeating_weapon_1_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_1_damage-dice-num}d@{repeating_weapon_1_damage-die} + (@{repeating_weapon_1_enhance} + @{repeating_weapon_1_damage} + @{repeating_weapon_1_damage-ability})]]&#x00A;Crit: @{repeating_weapon_1_crit-target}/x@{repeating_weapon_1_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_1_proficiency} + (((@{repeating_weapon_1_enhance} + @{repeating_weapon_1_masterwork}) + abs(@{repeating_weapon_1_enhance} - @{repeating_weapon_1_masterwork})) / 2) + @{repeating_weapon_1_attack} + @{repeating_weapon_1_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_1_damage-dice-num} * (@{repeating_weapon_1_crit-multiplier} - 1))d@{repeating_weapon_1_damage-die} + ((@{repeating_weapon_1_enhance} + @{repeating_weapon_1_damage} + @{repeating_weapon_1_damage-ability}) * (@{repeating_weapon_1_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_1_type}&#x00A;Notes: @{repeating_weapon_1_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_2_Attack" title="%{selected|repeating_weapon_2_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_2_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_2_proficiency} + (((@{repeating_weapon_2_enhance} + @{repeating_weapon_2_masterwork}) + abs(@{repeating_weapon_2_enhance} - @{repeating_weapon_2_masterwork})) / 2) + @{repeating_weapon_2_attack} + @{repeating_weapon_2_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_2_crit-target}) + (@{repeating_weapon_2_proficiency} + (((@{repeating_weapon_2_enhance} + @{repeating_weapon_2_masterwork}) + abs(@{repeating_weapon_2_enhance} - @{repeating_weapon_2_masterwork})) / 2) + @{repeating_weapon_2_attack} + @{repeating_weapon_2_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_2_damage-dice-num}d@{repeating_weapon_2_damage-die} + (@{repeating_weapon_2_enhance} + @{repeating_weapon_2_damage} + @{repeating_weapon_2_damage-ability})]]&#x00A;Crit: @{repeating_weapon_2_crit-target}/x@{repeating_weapon_2_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_2_proficiency} + (((@{repeating_weapon_2_enhance} + @{repeating_weapon_2_masterwork}) + abs(@{repeating_weapon_2_enhance} - @{repeating_weapon_2_masterwork})) / 2) + @{repeating_weapon_2_attack} + @{repeating_weapon_2_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_2_damage-dice-num} * (@{repeating_weapon_2_crit-multiplier} - 1))d@{repeating_weapon_2_damage-die} + ((@{repeating_weapon_2_enhance} + @{repeating_weapon_2_damage} + @{repeating_weapon_2_damage-ability}) * (@{repeating_weapon_2_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_2_type}&#x00A;Notes: @{repeating_weapon_2_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_3_Attack" title="%{selected|repeating_weapon_3_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_3_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_3_proficiency} + (((@{repeating_weapon_3_enhance} + @{repeating_weapon_3_masterwork}) + abs(@{repeating_weapon_3_enhance} - @{repeating_weapon_3_masterwork})) / 2) + @{repeating_weapon_3_attack} + @{repeating_weapon_3_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_3_crit-target}) + (@{repeating_weapon_3_proficiency} + (((@{repeating_weapon_3_enhance} + @{repeating_weapon_3_masterwork}) + abs(@{repeating_weapon_3_enhance} - @{repeating_weapon_3_masterwork})) / 2) + @{repeating_weapon_3_attack} + @{repeating_weapon_3_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_3_damage-dice-num}d@{repeating_weapon_3_damage-die} + (@{repeating_weapon_3_enhance} + @{repeating_weapon_3_damage} + @{repeating_weapon_3_damage-ability})]]&#x00A;Crit: @{repeating_weapon_3_crit-target}/x@{repeating_weapon_3_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_3_proficiency} + (((@{repeating_weapon_3_enhance} + @{repeating_weapon_3_masterwork}) + abs(@{repeating_weapon_3_enhance} - @{repeating_weapon_3_masterwork})) / 2) + @{repeating_weapon_3_attack} + @{repeating_weapon_3_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_3_damage-dice-num} * (@{repeating_weapon_3_crit-multiplier} - 1))d@{repeating_weapon_3_damage-die} + ((@{repeating_weapon_3_enhance} + @{repeating_weapon_3_damage} + @{repeating_weapon_3_damage-ability}) * (@{repeating_weapon_3_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_3_type}&#x00A;Notes: @{repeating_weapon_3_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_4_Attack" title="%{selected|repeating_weapon_4_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_4_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_4_proficiency} + (((@{repeating_weapon_4_enhance} + @{repeating_weapon_4_masterwork}) + abs(@{repeating_weapon_4_enhance} - @{repeating_weapon_4_masterwork})) / 2) + @{repeating_weapon_4_attack} + @{repeating_weapon_4_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_4_crit-target}) + (@{repeating_weapon_4_proficiency} + (((@{repeating_weapon_4_enhance} + @{repeating_weapon_4_masterwork}) + abs(@{repeating_weapon_4_enhance} - @{repeating_weapon_4_masterwork})) / 2) + @{repeating_weapon_4_attack} + @{repeating_weapon_4_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_4_damage-dice-num}d@{repeating_weapon_4_damage-die} + (@{repeating_weapon_4_enhance} + @{repeating_weapon_4_damage} + @{repeating_weapon_4_damage-ability})]]&#x00A;Crit: @{repeating_weapon_4_crit-target}/x@{repeating_weapon_4_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_4_proficiency} + (((@{repeating_weapon_4_enhance} + @{repeating_weapon_4_masterwork}) + abs(@{repeating_weapon_4_enhance} - @{repeating_weapon_4_masterwork})) / 2) + @{repeating_weapon_4_attack} + @{repeating_weapon_4_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_4_damage-dice-num} * (@{repeating_weapon_4_crit-multiplier} - 1))d@{repeating_weapon_4_damage-die} + ((@{repeating_weapon_4_enhance} + @{repeating_weapon_4_damage} + @{repeating_weapon_4_damage-ability}) * (@{repeating_weapon_4_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_4_type}&#x00A;Notes: @{repeating_weapon_4_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_5_Attack" title="%{selected|repeating_weapon_5_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_5_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_5_proficiency} + (((@{repeating_weapon_5_enhance} + @{repeating_weapon_5_masterwork}) + abs(@{repeating_weapon_5_enhance} - @{repeating_weapon_5_masterwork})) / 2) + @{repeating_weapon_5_attack} + @{repeating_weapon_5_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_5_crit-target}) + (@{repeating_weapon_5_proficiency} + (((@{repeating_weapon_5_enhance} + @{repeating_weapon_5_masterwork}) + abs(@{repeating_weapon_5_enhance} - @{repeating_weapon_5_masterwork})) / 2) + @{repeating_weapon_5_attack} + @{repeating_weapon_5_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_5_damage-dice-num}d@{repeating_weapon_5_damage-die} + (@{repeating_weapon_5_enhance} + @{repeating_weapon_5_damage} + @{repeating_weapon_5_damage-ability})]]&#x00A;Crit: @{repeating_weapon_5_crit-target}/x@{repeating_weapon_5_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_5_proficiency} + (((@{repeating_weapon_5_enhance} + @{repeating_weapon_5_masterwork}) + abs(@{repeating_weapon_5_enhance} - @{repeating_weapon_5_masterwork})) / 2) + @{repeating_weapon_5_attack} + @{repeating_weapon_5_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_5_damage-dice-num} * (@{repeating_weapon_5_crit-multiplier} - 1))d@{repeating_weapon_5_damage-die} + ((@{repeating_weapon_5_enhance} + @{repeating_weapon_5_damage} + @{repeating_weapon_5_damage-ability}) * (@{repeating_weapon_5_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_5_type}&#x00A;Notes: @{repeating_weapon_5_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_6_Attack" title="%{selected|repeating_weapon_6_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_6_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_6_proficiency} + (((@{repeating_weapon_6_enhance} + @{repeating_weapon_6_masterwork}) + abs(@{repeating_weapon_6_enhance} - @{repeating_weapon_6_masterwork})) / 2) + @{repeating_weapon_6_attack} + @{repeating_weapon_6_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_6_crit-target}) + (@{repeating_weapon_6_proficiency} + (((@{repeating_weapon_6_enhance} + @{repeating_weapon_6_masterwork}) + abs(@{repeating_weapon_6_enhance} - @{repeating_weapon_6_masterwork})) / 2) + @{repeating_weapon_6_attack} + @{repeating_weapon_6_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_6_damage-dice-num}d@{repeating_weapon_6_damage-die} + (@{repeating_weapon_6_enhance} + @{repeating_weapon_6_damage} + @{repeating_weapon_6_damage-ability})]]&#x00A;Crit: @{repeating_weapon_6_crit-target}/x@{repeating_weapon_6_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_6_proficiency} + (((@{repeating_weapon_6_enhance} + @{repeating_weapon_6_masterwork}) + abs(@{repeating_weapon_6_enhance} - @{repeating_weapon_6_masterwork})) / 2) + @{repeating_weapon_6_attack} + @{repeating_weapon_6_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_6_damage-dice-num} * (@{repeating_weapon_6_crit-multiplier} - 1))d@{repeating_weapon_6_damage-die} + ((@{repeating_weapon_6_enhance} + @{repeating_weapon_6_damage} + @{repeating_weapon_6_damage-ability}) * (@{repeating_weapon_6_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_6_type}&#x00A;Notes: @{repeating_weapon_6_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_7_Attack" title="%{selected|repeating_weapon_7_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_7_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_7_proficiency} + (((@{repeating_weapon_7_enhance} + @{repeating_weapon_7_masterwork}) + abs(@{repeating_weapon_7_enhance} - @{repeating_weapon_7_masterwork})) / 2) + @{repeating_weapon_7_attack} + @{repeating_weapon_7_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_7_crit-target}) + (@{repeating_weapon_7_proficiency} + (((@{repeating_weapon_7_enhance} + @{repeating_weapon_7_masterwork}) + abs(@{repeating_weapon_7_enhance} - @{repeating_weapon_7_masterwork})) / 2) + @{repeating_weapon_7_attack} + @{repeating_weapon_7_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_7_damage-dice-num}d@{repeating_weapon_7_damage-die} + (@{repeating_weapon_7_enhance} + @{repeating_weapon_7_damage} + @{repeating_weapon_7_damage-ability})]]&#x00A;Crit: @{repeating_weapon_7_crit-target}/x@{repeating_weapon_7_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_7_proficiency} + (((@{repeating_weapon_7_enhance} + @{repeating_weapon_7_masterwork}) + abs(@{repeating_weapon_7_enhance} - @{repeating_weapon_7_masterwork})) / 2) + @{repeating_weapon_7_attack} + @{repeating_weapon_7_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_7_damage-dice-num} * (@{repeating_weapon_7_crit-multiplier} - 1))d@{repeating_weapon_7_damage-die} + ((@{repeating_weapon_7_enhance} + @{repeating_weapon_7_damage} + @{repeating_weapon_7_damage-ability}) * (@{repeating_weapon_7_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_7_type}&#x00A;Notes: @{repeating_weapon_7_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_8_Attack" title="%{selected|repeating_weapon_8_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_8_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_8_proficiency} + (((@{repeating_weapon_8_enhance} + @{repeating_weapon_8_masterwork}) + abs(@{repeating_weapon_8_enhance} - @{repeating_weapon_8_masterwork})) / 2) + @{repeating_weapon_8_attack} + @{repeating_weapon_8_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_8_crit-target}) + (@{repeating_weapon_8_proficiency} + (((@{repeating_weapon_8_enhance} + @{repeating_weapon_8_masterwork}) + abs(@{repeating_weapon_8_enhance} - @{repeating_weapon_8_masterwork})) / 2) + @{repeating_weapon_8_attack} + @{repeating_weapon_8_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_8_damage-dice-num}d@{repeating_weapon_8_damage-die} + (@{repeating_weapon_8_enhance} + @{repeating_weapon_8_damage} + @{repeating_weapon_8_damage-ability})]]&#x00A;Crit: @{repeating_weapon_8_crit-target}/x@{repeating_weapon_8_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_8_proficiency} + (((@{repeating_weapon_8_enhance} + @{repeating_weapon_8_masterwork}) + abs(@{repeating_weapon_8_enhance} - @{repeating_weapon_8_masterwork})) / 2) + @{repeating_weapon_8_attack} + @{repeating_weapon_8_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_8_damage-dice-num} * (@{repeating_weapon_8_crit-multiplier} - 1))d@{repeating_weapon_8_damage-die} + ((@{repeating_weapon_8_enhance} + @{repeating_weapon_8_damage} + @{repeating_weapon_8_damage-ability}) * (@{repeating_weapon_8_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_8_type}&#x00A;Notes: @{repeating_weapon_8_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_9_Attack" title="%{selected|repeating_weapon_9_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_9_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_9_proficiency} + (((@{repeating_weapon_9_enhance} + @{repeating_weapon_9_masterwork}) + abs(@{repeating_weapon_9_enhance} - @{repeating_weapon_9_masterwork})) / 2) + @{repeating_weapon_9_attack} + @{repeating_weapon_9_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_9_crit-target}) + (@{repeating_weapon_9_proficiency} + (((@{repeating_weapon_9_enhance} + @{repeating_weapon_9_masterwork}) + abs(@{repeating_weapon_9_enhance} - @{repeating_weapon_9_masterwork})) / 2) + @{repeating_weapon_9_attack} + @{repeating_weapon_9_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_9_damage-dice-num}d@{repeating_weapon_9_damage-die} + (@{repeating_weapon_9_enhance} + @{repeating_weapon_9_damage} + @{repeating_weapon_9_damage-ability})]]&#x00A;Crit: @{repeating_weapon_9_crit-target}/x@{repeating_weapon_9_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_9_proficiency} + (((@{repeating_weapon_9_enhance} + @{repeating_weapon_9_masterwork}) + abs(@{repeating_weapon_9_enhance} - @{repeating_weapon_9_masterwork})) / 2) + @{repeating_weapon_9_attack} + @{repeating_weapon_9_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_9_damage-dice-num} * (@{repeating_weapon_9_crit-multiplier} - 1))d@{repeating_weapon_9_damage-die} + ((@{repeating_weapon_9_enhance} + @{repeating_weapon_9_damage} + @{repeating_weapon_9_damage-ability}) * (@{repeating_weapon_9_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_9_type}&#x00A;Notes: @{repeating_weapon_9_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_10_Attack" title="%{selected|repeating_weapon_10_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_10_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_10_proficiency} + (((@{repeating_weapon_10_enhance} + @{repeating_weapon_10_masterwork}) + abs(@{repeating_weapon_10_enhance} - @{repeating_weapon_10_masterwork})) / 2) + @{repeating_weapon_10_attack} + @{repeating_weapon_10_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_10_crit-target}) + (@{repeating_weapon_10_proficiency} + (((@{repeating_weapon_10_enhance} + @{repeating_weapon_10_masterwork}) + abs(@{repeating_weapon_10_enhance} - @{repeating_weapon_10_masterwork})) / 2) + @{repeating_weapon_10_attack} + @{repeating_weapon_10_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_10_damage-dice-num}d@{repeating_weapon_10_damage-die} + (@{repeating_weapon_10_enhance} + @{repeating_weapon_10_damage} + @{repeating_weapon_10_damage-ability})]]&#x00A;Crit: @{repeating_weapon_10_crit-target}/x@{repeating_weapon_10_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_10_proficiency} + (((@{repeating_weapon_10_enhance} + @{repeating_weapon_10_masterwork}) + abs(@{repeating_weapon_10_enhance} - @{repeating_weapon_10_masterwork})) / 2) + @{repeating_weapon_10_attack} + @{repeating_weapon_10_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_10_damage-dice-num} * (@{repeating_weapon_10_crit-multiplier} - 1))d@{repeating_weapon_10_damage-die} + ((@{repeating_weapon_10_enhance} + @{repeating_weapon_10_damage} + @{repeating_weapon_10_damage-ability}) * (@{repeating_weapon_10_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_10_type}&#x00A;Notes: @{repeating_weapon_10_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_11_Attack" title="%{selected|repeating_weapon_11_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_11_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_11_proficiency} + (((@{repeating_weapon_11_enhance} + @{repeating_weapon_11_masterwork}) + abs(@{repeating_weapon_11_enhance} - @{repeating_weapon_11_masterwork})) / 2) + @{repeating_weapon_11_attack} + @{repeating_weapon_11_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_11_crit-target}) + (@{repeating_weapon_11_proficiency} + (((@{repeating_weapon_11_enhance} + @{repeating_weapon_11_masterwork}) + abs(@{repeating_weapon_11_enhance} - @{repeating_weapon_11_masterwork})) / 2) + @{repeating_weapon_11_attack} + @{repeating_weapon_11_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_11_damage-dice-num}d@{repeating_weapon_11_damage-die} + (@{repeating_weapon_11_enhance} + @{repeating_weapon_11_damage} + @{repeating_weapon_11_damage-ability})]]&#x00A;Crit: @{repeating_weapon_11_crit-target}/x@{repeating_weapon_11_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_11_proficiency} + (((@{repeating_weapon_11_enhance} + @{repeating_weapon_11_masterwork}) + abs(@{repeating_weapon_11_enhance} - @{repeating_weapon_11_masterwork})) / 2) + @{repeating_weapon_11_attack} + @{repeating_weapon_11_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_11_damage-dice-num} * (@{repeating_weapon_11_crit-multiplier} - 1))d@{repeating_weapon_11_damage-die} + ((@{repeating_weapon_11_enhance} + @{repeating_weapon_11_damage} + @{repeating_weapon_11_damage-ability}) * (@{repeating_weapon_11_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_11_type}&#x00A;Notes: @{repeating_weapon_11_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_12_Attack" title="%{selected|repeating_weapon_12_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_12_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_12_proficiency} + (((@{repeating_weapon_12_enhance} + @{repeating_weapon_12_masterwork}) + abs(@{repeating_weapon_12_enhance} - @{repeating_weapon_12_masterwork})) / 2) + @{repeating_weapon_12_attack} + @{repeating_weapon_12_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_12_crit-target}) + (@{repeating_weapon_12_proficiency} + (((@{repeating_weapon_12_enhance} + @{repeating_weapon_12_masterwork}) + abs(@{repeating_weapon_12_enhance} - @{repeating_weapon_12_masterwork})) / 2) + @{repeating_weapon_12_attack} + @{repeating_weapon_12_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_12_damage-dice-num}d@{repeating_weapon_12_damage-die} + (@{repeating_weapon_12_enhance} + @{repeating_weapon_12_damage} + @{repeating_weapon_12_damage-ability})]]&#x00A;Crit: @{repeating_weapon_12_crit-target}/x@{repeating_weapon_12_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_12_proficiency} + (((@{repeating_weapon_12_enhance} + @{repeating_weapon_12_masterwork}) + abs(@{repeating_weapon_12_enhance} - @{repeating_weapon_12_masterwork})) / 2) + @{repeating_weapon_12_attack} + @{repeating_weapon_12_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_12_damage-dice-num} * (@{repeating_weapon_12_crit-multiplier} - 1))d@{repeating_weapon_12_damage-die} + ((@{repeating_weapon_12_enhance} + @{repeating_weapon_12_damage} + @{repeating_weapon_12_damage-ability}) * (@{repeating_weapon_12_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_12_type}&#x00A;Notes: @{repeating_weapon_12_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_13_Attack" title="%{selected|repeating_weapon_13_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_13_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_13_proficiency} + (((@{repeating_weapon_13_enhance} + @{repeating_weapon_13_masterwork}) + abs(@{repeating_weapon_13_enhance} - @{repeating_weapon_13_masterwork})) / 2) + @{repeating_weapon_13_attack} + @{repeating_weapon_13_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_13_crit-target}) + (@{repeating_weapon_13_proficiency} + (((@{repeating_weapon_13_enhance} + @{repeating_weapon_13_masterwork}) + abs(@{repeating_weapon_13_enhance} - @{repeating_weapon_13_masterwork})) / 2) + @{repeating_weapon_13_attack} + @{repeating_weapon_13_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_13_damage-dice-num}d@{repeating_weapon_13_damage-die} + (@{repeating_weapon_13_enhance} + @{repeating_weapon_13_damage} + @{repeating_weapon_13_damage-ability})]]&#x00A;Crit: @{repeating_weapon_13_crit-target}/x@{repeating_weapon_13_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_13_proficiency} + (((@{repeating_weapon_13_enhance} + @{repeating_weapon_13_masterwork}) + abs(@{repeating_weapon_13_enhance} - @{repeating_weapon_13_masterwork})) / 2) + @{repeating_weapon_13_attack} + @{repeating_weapon_13_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_13_damage-dice-num} * (@{repeating_weapon_13_crit-multiplier} - 1))d@{repeating_weapon_13_damage-die} + ((@{repeating_weapon_13_enhance} + @{repeating_weapon_13_damage} + @{repeating_weapon_13_damage-ability}) * (@{repeating_weapon_13_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_13_type}&#x00A;Notes: @{repeating_weapon_13_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_14_Attack" title="%{selected|repeating_weapon_14_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_14_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_14_proficiency} + (((@{repeating_weapon_14_enhance} + @{repeating_weapon_14_masterwork}) + abs(@{repeating_weapon_14_enhance} - @{repeating_weapon_14_masterwork})) / 2) + @{repeating_weapon_14_attack} + @{repeating_weapon_14_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_14_crit-target}) + (@{repeating_weapon_14_proficiency} + (((@{repeating_weapon_14_enhance} + @{repeating_weapon_14_masterwork}) + abs(@{repeating_weapon_14_enhance} - @{repeating_weapon_14_masterwork})) / 2) + @{repeating_weapon_14_attack} + @{repeating_weapon_14_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_14_damage-dice-num}d@{repeating_weapon_14_damage-die} + (@{repeating_weapon_14_enhance} + @{repeating_weapon_14_damage} + @{repeating_weapon_14_damage-ability})]]&#x00A;Crit: @{repeating_weapon_14_crit-target}/x@{repeating_weapon_14_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_14_proficiency} + (((@{repeating_weapon_14_enhance} + @{repeating_weapon_14_masterwork}) + abs(@{repeating_weapon_14_enhance} - @{repeating_weapon_14_masterwork})) / 2) + @{repeating_weapon_14_attack} + @{repeating_weapon_14_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_14_damage-dice-num} * (@{repeating_weapon_14_crit-multiplier} - 1))d@{repeating_weapon_14_damage-die} + ((@{repeating_weapon_14_enhance} + @{repeating_weapon_14_damage} + @{repeating_weapon_14_damage-ability}) * (@{repeating_weapon_14_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_14_type}&#x00A;Notes: @{repeating_weapon_14_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_15_Attack" title="%{selected|repeating_weapon_15_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_15_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_15_proficiency} + (((@{repeating_weapon_15_enhance} + @{repeating_weapon_15_masterwork}) + abs(@{repeating_weapon_15_enhance} - @{repeating_weapon_15_masterwork})) / 2) + @{repeating_weapon_15_attack} + @{repeating_weapon_15_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_15_crit-target}) + (@{repeating_weapon_15_proficiency} + (((@{repeating_weapon_15_enhance} + @{repeating_weapon_15_masterwork}) + abs(@{repeating_weapon_15_enhance} - @{repeating_weapon_15_masterwork})) / 2) + @{repeating_weapon_15_attack} + @{repeating_weapon_15_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_15_damage-dice-num}d@{repeating_weapon_15_damage-die} + (@{repeating_weapon_15_enhance} + @{repeating_weapon_15_damage} + @{repeating_weapon_15_damage-ability})]]&#x00A;Crit: @{repeating_weapon_15_crit-target}/x@{repeating_weapon_15_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_15_proficiency} + (((@{repeating_weapon_15_enhance} + @{repeating_weapon_15_masterwork}) + abs(@{repeating_weapon_15_enhance} - @{repeating_weapon_15_masterwork})) / 2) + @{repeating_weapon_15_attack} + @{repeating_weapon_15_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_15_damage-dice-num} * (@{repeating_weapon_15_crit-multiplier} - 1))d@{repeating_weapon_15_damage-die} + ((@{repeating_weapon_15_enhance} + @{repeating_weapon_15_damage} + @{repeating_weapon_15_damage-ability}) * (@{repeating_weapon_15_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_15_type}&#x00A;Notes: @{repeating_weapon_15_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_16_Attack" title="%{selected|repeating_weapon_16_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_16_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_16_proficiency} + (((@{repeating_weapon_16_enhance} + @{repeating_weapon_16_masterwork}) + abs(@{repeating_weapon_16_enhance} - @{repeating_weapon_16_masterwork})) / 2) + @{repeating_weapon_16_attack} + @{repeating_weapon_16_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_16_crit-target}) + (@{repeating_weapon_16_proficiency} + (((@{repeating_weapon_16_enhance} + @{repeating_weapon_16_masterwork}) + abs(@{repeating_weapon_16_enhance} - @{repeating_weapon_16_masterwork})) / 2) + @{repeating_weapon_16_attack} + @{repeating_weapon_16_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_16_damage-dice-num}d@{repeating_weapon_16_damage-die} + (@{repeating_weapon_16_enhance} + @{repeating_weapon_16_damage} + @{repeating_weapon_16_damage-ability})]]&#x00A;Crit: @{repeating_weapon_16_crit-target}/x@{repeating_weapon_16_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_16_proficiency} + (((@{repeating_weapon_16_enhance} + @{repeating_weapon_16_masterwork}) + abs(@{repeating_weapon_16_enhance} - @{repeating_weapon_16_masterwork})) / 2) + @{repeating_weapon_16_attack} + @{repeating_weapon_16_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_16_damage-dice-num} * (@{repeating_weapon_16_crit-multiplier} - 1))d@{repeating_weapon_16_damage-die} + ((@{repeating_weapon_16_enhance} + @{repeating_weapon_16_damage} + @{repeating_weapon_16_damage-ability}) * (@{repeating_weapon_16_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_16_type}&#x00A;Notes: @{repeating_weapon_16_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_17_Attack" title="%{selected|repeating_weapon_17_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_17_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_17_proficiency} + (((@{repeating_weapon_17_enhance} + @{repeating_weapon_17_masterwork}) + abs(@{repeating_weapon_17_enhance} - @{repeating_weapon_17_masterwork})) / 2) + @{repeating_weapon_17_attack} + @{repeating_weapon_17_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_17_crit-target}) + (@{repeating_weapon_17_proficiency} + (((@{repeating_weapon_17_enhance} + @{repeating_weapon_17_masterwork}) + abs(@{repeating_weapon_17_enhance} - @{repeating_weapon_17_masterwork})) / 2) + @{repeating_weapon_17_attack} + @{repeating_weapon_17_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_17_damage-dice-num}d@{repeating_weapon_17_damage-die} + (@{repeating_weapon_17_enhance} + @{repeating_weapon_17_damage} + @{repeating_weapon_17_damage-ability})]]&#x00A;Crit: @{repeating_weapon_17_crit-target}/x@{repeating_weapon_17_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_17_proficiency} + (((@{repeating_weapon_17_enhance} + @{repeating_weapon_17_masterwork}) + abs(@{repeating_weapon_17_enhance} - @{repeating_weapon_17_masterwork})) / 2) + @{repeating_weapon_17_attack} + @{repeating_weapon_17_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_17_damage-dice-num} * (@{repeating_weapon_17_crit-multiplier} - 1))d@{repeating_weapon_17_damage-die} + ((@{repeating_weapon_17_enhance} + @{repeating_weapon_17_damage} + @{repeating_weapon_17_damage-ability}) * (@{repeating_weapon_17_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_17_type}&#x00A;Notes: @{repeating_weapon_17_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_18_Attack" title="%{selected|repeating_weapon_18_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_18_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_18_proficiency} + (((@{repeating_weapon_18_enhance} + @{repeating_weapon_18_masterwork}) + abs(@{repeating_weapon_18_enhance} - @{repeating_weapon_18_masterwork})) / 2) + @{repeating_weapon_18_attack} + @{repeating_weapon_18_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_18_crit-target}) + (@{repeating_weapon_18_proficiency} + (((@{repeating_weapon_18_enhance} + @{repeating_weapon_18_masterwork}) + abs(@{repeating_weapon_18_enhance} - @{repeating_weapon_18_masterwork})) / 2) + @{repeating_weapon_18_attack} + @{repeating_weapon_18_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_18_damage-dice-num}d@{repeating_weapon_18_damage-die} + (@{repeating_weapon_18_enhance} + @{repeating_weapon_18_damage} + @{repeating_weapon_18_damage-ability})]]&#x00A;Crit: @{repeating_weapon_18_crit-target}/x@{repeating_weapon_18_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_18_proficiency} + (((@{repeating_weapon_18_enhance} + @{repeating_weapon_18_masterwork}) + abs(@{repeating_weapon_18_enhance} - @{repeating_weapon_18_masterwork})) / 2) + @{repeating_weapon_18_attack} + @{repeating_weapon_18_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_18_damage-dice-num} * (@{repeating_weapon_18_crit-multiplier} - 1))d@{repeating_weapon_18_damage-die} + ((@{repeating_weapon_18_enhance} + @{repeating_weapon_18_damage} + @{repeating_weapon_18_damage-ability}) * (@{repeating_weapon_18_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_18_type}&#x00A;Notes: @{repeating_weapon_18_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_19_Attack" title="%{selected|repeating_weapon_19_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_19_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_19_proficiency} + (((@{repeating_weapon_19_enhance} + @{repeating_weapon_19_masterwork}) + abs(@{repeating_weapon_19_enhance} - @{repeating_weapon_19_masterwork})) / 2) + @{repeating_weapon_19_attack} + @{repeating_weapon_19_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_19_crit-target}) + (@{repeating_weapon_19_proficiency} + (((@{repeating_weapon_19_enhance} + @{repeating_weapon_19_masterwork}) + abs(@{repeating_weapon_19_enhance} - @{repeating_weapon_19_masterwork})) / 2) + @{repeating_weapon_19_attack} + @{repeating_weapon_19_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_19_damage-dice-num}d@{repeating_weapon_19_damage-die} + (@{repeating_weapon_19_enhance} + @{repeating_weapon_19_damage} + @{repeating_weapon_19_damage-ability})]]&#x00A;Crit: @{repeating_weapon_19_crit-target}/x@{repeating_weapon_19_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_19_proficiency} + (((@{repeating_weapon_19_enhance} + @{repeating_weapon_19_masterwork}) + abs(@{repeating_weapon_19_enhance} - @{repeating_weapon_19_masterwork})) / 2) + @{repeating_weapon_19_attack} + @{repeating_weapon_19_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_19_damage-dice-num} * (@{repeating_weapon_19_crit-multiplier} - 1))d@{repeating_weapon_19_damage-die} + ((@{repeating_weapon_19_enhance} + @{repeating_weapon_19_damage} + @{repeating_weapon_19_damage-ability}) * (@{repeating_weapon_19_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_19_type}&#x00A;Notes: @{repeating_weapon_19_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_20_Attack" title="%{selected|repeating_weapon_20_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_20_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_20_proficiency} + (((@{repeating_weapon_20_enhance} + @{repeating_weapon_20_masterwork}) + abs(@{repeating_weapon_20_enhance} - @{repeating_weapon_20_masterwork})) / 2) + @{repeating_weapon_20_attack} + @{repeating_weapon_20_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_20_crit-target}) + (@{repeating_weapon_20_proficiency} + (((@{repeating_weapon_20_enhance} + @{repeating_weapon_20_masterwork}) + abs(@{repeating_weapon_20_enhance} - @{repeating_weapon_20_masterwork})) / 2) + @{repeating_weapon_20_attack} + @{repeating_weapon_20_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_20_damage-dice-num}d@{repeating_weapon_20_damage-die} + (@{repeating_weapon_20_enhance} + @{repeating_weapon_20_damage} + @{repeating_weapon_20_damage-ability})]]&#x00A;Crit: @{repeating_weapon_20_crit-target}/x@{repeating_weapon_20_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_20_proficiency} + (((@{repeating_weapon_20_enhance} + @{repeating_weapon_20_masterwork}) + abs(@{repeating_weapon_20_enhance} - @{repeating_weapon_20_masterwork})) / 2) + @{repeating_weapon_20_attack} + @{repeating_weapon_20_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_20_damage-dice-num} * (@{repeating_weapon_20_crit-multiplier} - 1))d@{repeating_weapon_20_damage-die} + ((@{repeating_weapon_20_enhance} + @{repeating_weapon_20_damage} + @{repeating_weapon_20_damage-ability}) * (@{repeating_weapon_20_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_20_type}&#x00A;Notes: @{repeating_weapon_20_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_21_Attack" title="%{selected|repeating_weapon_21_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_21_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_21_proficiency} + (((@{repeating_weapon_21_enhance} + @{repeating_weapon_21_masterwork}) + abs(@{repeating_weapon_21_enhance} - @{repeating_weapon_21_masterwork})) / 2) + @{repeating_weapon_21_attack} + @{repeating_weapon_21_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_21_crit-target}) + (@{repeating_weapon_21_proficiency} + (((@{repeating_weapon_21_enhance} + @{repeating_weapon_21_masterwork}) + abs(@{repeating_weapon_21_enhance} - @{repeating_weapon_21_masterwork})) / 2) + @{repeating_weapon_21_attack} + @{repeating_weapon_21_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_21_damage-dice-num}d@{repeating_weapon_21_damage-die} + (@{repeating_weapon_21_enhance} + @{repeating_weapon_21_damage} + @{repeating_weapon_21_damage-ability})]]&#x00A;Crit: @{repeating_weapon_21_crit-target}/x@{repeating_weapon_21_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_21_proficiency} + (((@{repeating_weapon_21_enhance} + @{repeating_weapon_21_masterwork}) + abs(@{repeating_weapon_21_enhance} - @{repeating_weapon_21_masterwork})) / 2) + @{repeating_weapon_21_attack} + @{repeating_weapon_21_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_21_damage-dice-num} * (@{repeating_weapon_21_crit-multiplier} - 1))d@{repeating_weapon_21_damage-die} + ((@{repeating_weapon_21_enhance} + @{repeating_weapon_21_damage} + @{repeating_weapon_21_damage-ability}) * (@{repeating_weapon_21_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_21_type}&#x00A;Notes: @{repeating_weapon_21_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_22_Attack" title="%{selected|repeating_weapon_22_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_22_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_22_proficiency} + (((@{repeating_weapon_22_enhance} + @{repeating_weapon_22_masterwork}) + abs(@{repeating_weapon_22_enhance} - @{repeating_weapon_22_masterwork})) / 2) + @{repeating_weapon_22_attack} + @{repeating_weapon_22_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_22_crit-target}) + (@{repeating_weapon_22_proficiency} + (((@{repeating_weapon_22_enhance} + @{repeating_weapon_22_masterwork}) + abs(@{repeating_weapon_22_enhance} - @{repeating_weapon_22_masterwork})) / 2) + @{repeating_weapon_22_attack} + @{repeating_weapon_22_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_22_damage-dice-num}d@{repeating_weapon_22_damage-die} + (@{repeating_weapon_22_enhance} + @{repeating_weapon_22_damage} + @{repeating_weapon_22_damage-ability})]]&#x00A;Crit: @{repeating_weapon_22_crit-target}/x@{repeating_weapon_22_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_22_proficiency} + (((@{repeating_weapon_22_enhance} + @{repeating_weapon_22_masterwork}) + abs(@{repeating_weapon_22_enhance} - @{repeating_weapon_22_masterwork})) / 2) + @{repeating_weapon_22_attack} + @{repeating_weapon_22_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_22_damage-dice-num} * (@{repeating_weapon_22_crit-multiplier} - 1))d@{repeating_weapon_22_damage-die} + ((@{repeating_weapon_22_enhance} + @{repeating_weapon_22_damage} + @{repeating_weapon_22_damage-ability}) * (@{repeating_weapon_22_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_22_type}&#x00A;Notes: @{repeating_weapon_22_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_23_Attack" title="%{selected|repeating_weapon_23_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_23_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_23_proficiency} + (((@{repeating_weapon_23_enhance} + @{repeating_weapon_23_masterwork}) + abs(@{repeating_weapon_23_enhance} - @{repeating_weapon_23_masterwork})) / 2) + @{repeating_weapon_23_attack} + @{repeating_weapon_23_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_23_crit-target}) + (@{repeating_weapon_23_proficiency} + (((@{repeating_weapon_23_enhance} + @{repeating_weapon_23_masterwork}) + abs(@{repeating_weapon_23_enhance} - @{repeating_weapon_23_masterwork})) / 2) + @{repeating_weapon_23_attack} + @{repeating_weapon_23_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_23_damage-dice-num}d@{repeating_weapon_23_damage-die} + (@{repeating_weapon_23_enhance} + @{repeating_weapon_23_damage} + @{repeating_weapon_23_damage-ability})]]&#x00A;Crit: @{repeating_weapon_23_crit-target}/x@{repeating_weapon_23_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_23_proficiency} + (((@{repeating_weapon_23_enhance} + @{repeating_weapon_23_masterwork}) + abs(@{repeating_weapon_23_enhance} - @{repeating_weapon_23_masterwork})) / 2) + @{repeating_weapon_23_attack} + @{repeating_weapon_23_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_23_damage-dice-num} * (@{repeating_weapon_23_crit-multiplier} - 1))d@{repeating_weapon_23_damage-die} + ((@{repeating_weapon_23_enhance} + @{repeating_weapon_23_damage} + @{repeating_weapon_23_damage-ability}) * (@{repeating_weapon_23_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_23_type}&#x00A;Notes: @{repeating_weapon_23_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_24_Attack" title="%{selected|repeating_weapon_24_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_24_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_24_proficiency} + (((@{repeating_weapon_24_enhance} + @{repeating_weapon_24_masterwork}) + abs(@{repeating_weapon_24_enhance} - @{repeating_weapon_24_masterwork})) / 2) + @{repeating_weapon_24_attack} + @{repeating_weapon_24_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_24_crit-target}) + (@{repeating_weapon_24_proficiency} + (((@{repeating_weapon_24_enhance} + @{repeating_weapon_24_masterwork}) + abs(@{repeating_weapon_24_enhance} - @{repeating_weapon_24_masterwork})) / 2) + @{repeating_weapon_24_attack} + @{repeating_weapon_24_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_24_damage-dice-num}d@{repeating_weapon_24_damage-die} + (@{repeating_weapon_24_enhance} + @{repeating_weapon_24_damage} + @{repeating_weapon_24_damage-ability})]]&#x00A;Crit: @{repeating_weapon_24_crit-target}/x@{repeating_weapon_24_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_24_proficiency} + (((@{repeating_weapon_24_enhance} + @{repeating_weapon_24_masterwork}) + abs(@{repeating_weapon_24_enhance} - @{repeating_weapon_24_masterwork})) / 2) + @{repeating_weapon_24_attack} + @{repeating_weapon_24_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_24_damage-dice-num} * (@{repeating_weapon_24_crit-multiplier} - 1))d@{repeating_weapon_24_damage-die} + ((@{repeating_weapon_24_enhance} + @{repeating_weapon_24_damage} + @{repeating_weapon_24_damage-ability}) * (@{repeating_weapon_24_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_24_type}&#x00A;Notes: @{repeating_weapon_24_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_25_Attack" title="%{selected|repeating_weapon_25_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_25_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_25_proficiency} + (((@{repeating_weapon_25_enhance} + @{repeating_weapon_25_masterwork}) + abs(@{repeating_weapon_25_enhance} - @{repeating_weapon_25_masterwork})) / 2) + @{repeating_weapon_25_attack} + @{repeating_weapon_25_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_25_crit-target}) + (@{repeating_weapon_25_proficiency} + (((@{repeating_weapon_25_enhance} + @{repeating_weapon_25_masterwork}) + abs(@{repeating_weapon_25_enhance} - @{repeating_weapon_25_masterwork})) / 2) + @{repeating_weapon_25_attack} + @{repeating_weapon_25_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_25_damage-dice-num}d@{repeating_weapon_25_damage-die} + (@{repeating_weapon_25_enhance} + @{repeating_weapon_25_damage} + @{repeating_weapon_25_damage-ability})]]&#x00A;Crit: @{repeating_weapon_25_crit-target}/x@{repeating_weapon_25_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_25_proficiency} + (((@{repeating_weapon_25_enhance} + @{repeating_weapon_25_masterwork}) + abs(@{repeating_weapon_25_enhance} - @{repeating_weapon_25_masterwork})) / 2) + @{repeating_weapon_25_attack} + @{repeating_weapon_25_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_25_damage-dice-num} * (@{repeating_weapon_25_crit-multiplier} - 1))d@{repeating_weapon_25_damage-die} + ((@{repeating_weapon_25_enhance} + @{repeating_weapon_25_damage} + @{repeating_weapon_25_damage-ability}) * (@{repeating_weapon_25_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_25_type}&#x00A;Notes: @{repeating_weapon_25_notes}&#x00A;@{attack-notes}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_26_Attack" title="%{selected|repeating_weapon_26_Attack}" value="/em is attacking @{target|token_name} @{repeating_weapon_26_name}&#x00A;Attack Result: [[1d20 + (@{repeating_weapon_26_proficiency} + (((@{repeating_weapon_26_enhance} + @{repeating_weapon_26_masterwork}) + abs(@{repeating_weapon_26_enhance} - @{repeating_weapon_26_masterwork})) / 2) + @{repeating_weapon_26_attack} + @{repeating_weapon_26_attack-type} + @{armor-proficiency})]]&#x00A;(Needs at least [[(@{repeating_weapon_26_crit-target}) + (@{repeating_weapon_26_proficiency} + (((@{repeating_weapon_26_enhance} + @{repeating_weapon_26_masterwork}) + abs(@{repeating_weapon_26_enhance} - @{repeating_weapon_26_masterwork})) / 2) + @{repeating_weapon_26_attack} + @{repeating_weapon_26_attack-type} + @{armor-proficiency})]] to crit.)&#x00A;Damage Result: [[@{repeating_weapon_26_damage-dice-num}d@{repeating_weapon_26_damage-die} + (@{repeating_weapon_26_enhance} + @{repeating_weapon_26_damage} + @{repeating_weapon_26_damage-ability})]]&#x00A;Crit: @{repeating_weapon_26_crit-target}/x@{repeating_weapon_26_crit-multiplier}&#x00A;Crit Confirm: [[1d20 + (@{repeating_weapon_26_proficiency} + (((@{repeating_weapon_26_enhance} + @{repeating_weapon_26_masterwork}) + abs(@{repeating_weapon_26_enhance} - @{repeating_weapon_26_masterwork})) / 2) + @{repeating_weapon_26_attack} + @{repeating_weapon_26_attack-type} + @{armor-proficiency})]]&#x00A;Crit Damage: +[[(@{repeating_weapon_26_damage-dice-num} * (@{repeating_weapon_26_crit-multiplier} - 1))d@{repeating_weapon_26_damage-die} + ((@{repeating_weapon_26_enhance} + @{repeating_weapon_26_damage} + @{repeating_weapon_26_damage-ability}) * (@{repeating_weapon_26_crit-multiplier} - 1))]]&#x00A;Type: @{repeating_weapon_26_type}&#x00A;Notes: @{repeating_weapon_26_notes}&#x00A;@{attack-notes}"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Attacks</span>
+		</div>
+		<div class="sheet-sect">
+			<fieldset class="repeating_weapon">  
+				<div class="sheet-table">
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" min="0" name="attr_enhance" title="@{repeating_weapon_X_enhance}"><br>Enhance</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="checkbox" name="attr_masterwork" title="@{repeating_weapon_X_masterwork}" value="1"><br>Mwk</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_name" title="@{repeating_weapon_X_name}" placeholder="Name"><br>Name</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_attack" title="@{repeating_weapon_X_attack}" placeholder="Attack Modifiers"><br>Attack Mods</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;">
+							<select title="@{repeating_weapon_X_attack-type}" name="attr_attack-type">
+								<option value="0" selected>None</option>
+								<option value="@{attk-melee}">Melee</option>
+								<option value="@{attk-ranged}">Ranged</option>
+							</select>
+							<br>Attack Type
+						</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_total-attack" title="@{repeating_weapon_X_total-attack}" value="(@{proficiency} + (((@{enhance} + @{masterwork}) + abs(@{enhance} - @{masterwork})) / 2) + @{attack} + @{attack-type} + @{armor-proficiency})" disabled><br>ATK</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_damage-dice-num" title="@{repeating_weapon_X_damage-dice-num}" min="0"><br>Dice</span>
+						<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;width:2%;">d</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_damage-die" title="@{repeating_weapon_X_damage-die}" min="0"><br>Die</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_damage" title="@{repeating_weapon_X_damage}" placeholder="Damage Modifiers"><br>Damage Mods</span>
+						<span class="sheet-table-data sheet-center" style="width:15%;">
+							<select title="@{repeating_weapon_X_damage-ability}" name="attr_damage-ability">
+								<option value="0" selected>None</option>
+								<option value="floor(0.5 * @{STR-mod})">1/2 STR</option>
+								<option value="floor(0.5 * @{DEX-mod})">1/2 DEX</option>
+								<option value="floor(0.5 * @{CON-mod})">1/2 CON</option>
+								<option value="floor(0.5 * @{INT-mod})">1/2 INT</option>
+								<option value="floor(0.5 * @{WIS-mod})">1/2 WIS</option>
+								<option value="floor(0.5 * @{CHA-mod})">1/2 CHA</option>
+								<option value="@{STR-mod}">STR</option>
+								<option value="@{DEX-mod}">DEX</option>
+								<option value="@{CON-mod}">CON</option>
+								<option value="@{INT-mod}">INT</option>
+								<option value="@{WIS-mod}">WIS</option>
+								<option value="@{CHA-mod}">CHA</option>
+								<option value="floor(1.5 * @{STR-mod})">1.5x STR</option>
+								<option value="floor(1.5 * @{DEX-mod})">1.5x DEX</option>
+								<option value="floor(1.5 * @{CON-mod})">1.5x CON</option>
+								<option value="floor(1.5 * @{INT-mod})">1.5x INT</option>
+								<option value="floor(1.5 * @{WIS-mod})">1.5x WIS</option>
+								<option value="floor(1.5 * @{CHA-mod})">1.5x CHA</option>
+								<option value="floor(2 * @{STR-mod})">2x STR</option>
+								<option value="floor(2 * @{DEX-mod})">2x DEX</option>
+								<option value="floor(2 * @{CON-mod})">2x CON</option>
+								<option value="floor(2 * @{INT-mod})">2x INT</option>
+								<option value="floor(2 * @{WIS-mod})">2x WIS</option>
+								<option value="floor(2 * @{CHA-mod})">2x CHA</option>
+							</select>
+							<br>Damage Ability
+						</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_total-damage" title="@{repeating_weapon_X_total-damage}" value="(@{enhance} + @{damage} + @{damage-ability})" disabled><br>DMG</span>
+					</div>
+				</div>
+				<div class="sheet-table">
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_crit-target" title="@{repeating_weapon_X_crit-target}" min="0" max="20"><br>Crit</span>
+						<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;width:2%;"><b>/x</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_crit-multiplier" title="@{repeating_weapon_X_crit-multiplier}" min="0"><br>Multiplier</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_range" title="@{repeating_weapon_X_range}" value="0" min="0"><br>Range</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_type" title="@{repeating_weapon_X_type}" placeholder="Damage Type"><br>Damage Type</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_weight" title="@{repeating_weapon_X_weight}" value="0" step="any" min="0"><br>Weight</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_ammo" title="@{repeating_weapon_X_ammo}" value="0"><br>Ammo</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;">
+							<select title="@{repeating_weapon_X_proficiency}" name="attr_proficiency">
+								<option value="0">Yes</option>
+								<option value="-4" selected>No</option>
+							</select>
+							<br>Proficiency
+						</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:48%;"><input type="text" name="attr_notes" title="@{repeating_weapon_X_notes}" placeholder="Attack Notes"><br>Notes</span>
+					</div>
+				</div>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_weapon_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_weapon_X_macro-text}" name="attr_macro-text">/em is attacking @{target|token_name} with @{name}!&#x00A;Attack Result: [[1d20 + @{total-attack}]]&#x00A;(Needs at least [[(@{crit-target}) + @{total-attack}]] to crit.)&#x00A;Damage Result: [[@{damage-dice-num}d@{damage-die} + @{total-damage}]]&#x00A;Crit: @{crit-target}/x@{crit-multiplier}&#x00A;Crit Confirm: [[1d20 + @{total-attack}]]&#x00A;Crit Damage: +[[(@{damage-dice-num} * (@{crit-multiplier} - 1))d@{damage-die} + (@{total-damage} * (@{crit-multiplier} - 1))]]&#x00A;Type: @{type}&#x00A;Notes: @{notes}&#x00A;@{attack-notes}</textarea>
+				<hr>		
+			</fieldset>
+		</div>
+	</div>
+</div>
+<div class="sheet-section sheet-section-skills">
+ 	<div>
+		<b>Skill Ranks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{skill-ranks-show}" name="attr_skill-ranks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Skill Ranks</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">Max Skill Ranks Formula</span>
+				<span class="sheet-table-header">|</span>
+				<span class="sheet-table-header">Max Skill Ranks</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Total Skill Ranks</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Skill Ranks Remaining</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><input type="text" title="@{Max-Skill-Ranks-formula}" name="attr_Max-Skill-Ranks-formula" value="(((@{class-0-skill} * @{class-0-level}) + (@{class-1-skill} * @{class-1-level}) + (@{class-2-skill} * @{class-2-level}) + (@{class-3-skill} * @{class-3-level}) + (@{class-4-skill} * @{class-4-level}) + @{class-0-fcskill} + @{class-1-fcskill} + @{class-2-fcskill} + @{class-3-fcskill} + @{class-4-fcskill}) + (@{INT-mod} * @{level}))"></span>
+				<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;width:2%;">|</span>
+				<span class="sheet-table-data sheet-center"><input type="number" title="@{Max-Skill-Ranks}" name="attr_Max-Skill-Ranks" value="@{total-skill}" disabled></span>
+				<span class="sheet-table-data sheet-center">-</span>
+				<span class="sheet-table-data sheet-center"><input type="number" title="@{Total-Skill-Ranks}" name="attr_Total-Skill-Ranks" value="(@{Acrobatics-ranks} + @{Appraise-ranks} + @{Bluff-ranks} + @{Climb-ranks} + @{Craft-ranks} + @{Craft2-ranks} + @{Craft3-ranks} + @{Diplomacy-ranks} + @{Disable-Device-ranks} + @{Disguise-ranks} + @{Escape-Artist-ranks} + @{Fly-ranks} + @{Handle-Animal-ranks} + @{Heal-ranks} + @{Intimidate-ranks} + @{Knowledge-Arcana-ranks} + @{Knowledge-Dungeoneering-ranks} + @{Knowledge-Engineering-ranks} + @{Knowledge-Geography-ranks} + @{Knowledge-History-ranks} + @{Knowledge-Local-ranks} + @{Knowledge-Nature-ranks} + @{Knowledge-Nobility-ranks} + @{Knowledge-Planes-ranks} + @{Knowledge-Religion-ranks} + @{Linguistics-ranks} + @{Perception-ranks} + @{Perform-ranks} + @{Perform2-ranks} + @{Perform3-ranks} + @{Profession-ranks} + @{Profession2-ranks} + @{Profession3-ranks} + @{Ride-ranks} + @{Sense-Motive-ranks} + @{Sleight-of-Hand-ranks} + @{Spellcraft-ranks} + @{Stealth-ranks} + @{Survival-ranks} + @{Swim-ranks} + @{Use-Magic-Device-ranks} + @{Misc-Skill-0-ranks} + @{Misc-Skill-1-ranks} + @{Misc-Skill-2-ranks} + @{Misc-Skill-3-ranks} + @{Misc-Skill-4-ranks} + @{Misc-Skill-5-ranks})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input type="number" title="@{Skill-Ranks-Remaining}" name="attr_Skill-Ranks-Remaining" value="(@{Max-Skill-Ranks} - @{Total-Skill-Ranks})" disabled></span>
+			</div>
+		</div>
+		<br>
+	</div>
+ 	<div>
+		<b>Skills&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{skills-show}" name="attr_skills-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Skills</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">CS</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Skill</span>
+				<span class="sheet-table-header">Total</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Ranks</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Class</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Ability</span>
+				<span class="sheet-table-header">Mod</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Racial</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Feat</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Item</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">ACP</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Misc</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Acrobatics-Check}" type="roll" value="@{character_name}'s Acrobatics check: [[1d20 + @{Acrobatics}]]" name="roll_Acrobatics-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics-cs}" type="checkbox" name="attr_Acrobatics-cs" value="((((3 * @{Acrobatics-ranks}) + 3) - abs((3 * @{Acrobatics-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Acrobatics</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics}" type="number" name="attr_Acrobatics" value="(@{Acrobatics-ranks} + @{Acrobatics-class} + @{Acrobatics-ability} + @{Acrobatics-racial} + @{Acrobatics-feat} + @{Acrobatics-item} + @{Acrobatics-acp} + @{Acrobatics-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics-ranks}" type="number" name="attr_Acrobatics-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics-class}" type="number" name="attr_Acrobatics-class" value="@{Acrobatics-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Acrobatics-ability}" name="attr_Acrobatics-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}" selected>DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics-ability}" type="number" name="attr_Acrobatics-ability-display" value="@{Acrobatics-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics-racial}" type="number" name="attr_Acrobatics-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics-feat}" type="number" name="attr_Acrobatics-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics-item}" type="number" name="attr_Acrobatics-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics-acp}" type="number" name="attr_Acrobatics-acp" value="@{acp}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Acrobatics-misc}" type="number" name="attr_Acrobatics-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Appraise-Check}" type="roll" value="@{character_name}'s Appraise check: [[1d20 + @{Appraise}]]" name="roll_Appraise-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Appraise-cs}" type="checkbox" name="attr_Appraise-cs" value="((((3 * @{Appraise-ranks}) + 3) - abs((3 * @{Appraise-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Appraise</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Appraise}" type="number" name="attr_Appraise" value="(@{Appraise-ranks} + @{Appraise-class} + @{Appraise-ability} + @{Appraise-racial} + @{Appraise-feat} + @{Appraise-item} + @{Appraise-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Appraise-ranks}" type="number" name="attr_Appraise-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Appraise-class}" type="number" name="attr_Appraise-class" value="@{Appraise-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Appraise-ability}" name="attr_Appraise-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Appraise-ability}" type="number" name="attr_Appraise-ability-display" value="@{Appraise-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Appraise-racial}" type="number" name="attr_Appraise-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Appraise-feat}" type="number" name="attr_Appraise-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Appraise-item}" type="number" name="attr_Appraise-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Appraise-misc}" type="number" name="attr_Appraise-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Bluff-Check}" type="roll" value="@{character_name}'s Bluff check: [[1d20 + @{Bluff}]]" name="roll_Bluff-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Bluff-cs}" type="checkbox" name="attr_Bluff-cs" value="((((3 * @{Bluff-ranks}) + 3) - abs((3 * @{Bluff-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Bluff</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Bluff}" type="number" name="attr_Bluff" value="(@{Bluff-ranks} + @{Bluff-class} + @{Bluff-ability} + @{Bluff-racial} + @{Bluff-feat} + @{Bluff-item} + @{Bluff-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Bluff-ranks}" type="number" name="attr_Bluff-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Bluff-class}" type="number" name="attr_Bluff-class" value="@{Bluff-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Bluff-ability}" name="attr_Bluff-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}" selected>CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Bluff-ability}" type="number" name="attr_Bluff-ability-display" value="@{Bluff-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Bluff-racial}" type="number" name="attr_Bluff-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Bluff-feat}" type="number" name="attr_Bluff-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Bluff-item}" type="number" name="attr_Bluff-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Bluff-misc}" type="number" name="attr_Bluff-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Climb-Check}" type="roll" value="@{character_name}'s Climb check: [[1d20 + @{Climb}]]" name="roll_Climb-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Climb-cs}" type="checkbox" name="attr_Climb-cs" value="((((3 * @{Climb-ranks}) + 3) - abs((3 * @{Climb-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Climb</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Climb}" type="number" name="attr_Climb" value="(@{Climb-ranks} + @{Climb-class} + @{Climb-ability} + @{Climb-racial} + @{Climb-feat} + @{Climb-item} + @{Climb-acp} + @{Climb-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Climb-ranks}" type="number" name="attr_Climb-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Climb-class}" type="number" name="attr_Climb-class" value="@{Climb-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Climb-ability}" name="attr_Climb-ability">
+						<option value="@{STR-mod}" selected>STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Climb-ability}" type="number" name="attr_Climb-ability-display" value="@{Climb-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Climb-racial}" type="number" name="attr_Climb-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Climb-feat}" type="number" name="attr_Climb-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Climb-item}" type="number" name="attr_Climb-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Climb-acp}" type="number" name="attr_Climb-acp" value="@{acp}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Climb-misc}" type="number" name="attr_Climb-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft-Check}" type="roll" value="@{character_name}'s Craft: @{Craft-name} check: [[1d20 + @{Craft}]]" name="roll_Craft-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft-cs}" type="checkbox" name="attr_Craft-cs" value="((((3 * @{Craft-ranks}) + 3) - abs((3 * @{Craft-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft-name}" style="width:auto;" type="text" name="attr_Craft-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft}" type="number" name="attr_Craft" value="(@{Craft-ranks} + @{Craft-class} + @{Craft-ability} + @{Craft-racial} + @{Craft-feat} + @{Craft-item} + @{Craft-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft-ranks}" type="number" name="attr_Craft-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft-class}" type="number" name="attr_Craft-class" value="@{Craft-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Craft-ability}" name="attr_Craft-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft-ability}" type="number" name="attr_Craft-ability-display" value="@{Craft-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft-racial}" type="number" name="attr_Craft-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft-feat}" type="number" name="attr_Craft-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft-item}" type="number" name="attr_Craft-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft-misc}" type="number" name="attr_Craft-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft2-Check}" type="roll" value="@{character_name}'s Craft: @{Craft2-name} check: [[1d20 + @{Craft2}]]" name="roll_Craft2-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft2-cs}" type="checkbox" name="attr_Craft2-cs" value="((((3 * @{Craft2-ranks}) + 3) - abs((3 * @{Craft2-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft2-name}" style="width:auto;" type="text" name="attr_Craft2-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft2}" type="number" name="attr_Craft2" value="(@{Craft2-ranks} + @{Craft2-class} + @{Craft2-ability} + @{Craft2-racial} + @{Craft2-feat} + @{Craft2-item} + @{Craft2-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft2-ranks}" type="number" name="attr_Craft2-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft2-class}" type="number" name="attr_Craft2-class" value="@{Craft2-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Craft2-ability}" name="attr_Craft2-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft2-ability}" type="number" name="attr_Craft2-ability-display" value="@{Craft2-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft2-racial}" type="number" name="attr_Craft2-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft2-feat}" type="number" name="attr_Craft2-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft2-item}" type="number" name="attr_Craft2-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft2-misc}" type="number" name="attr_Craft2-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft3-Check}" type="roll" value="@{character_name}'s Craft: @{Craft3-name} check: [[1d20 + @{Craft3}]]" name="roll_Craft3-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft3-cs}" type="checkbox" name="attr_Craft3-cs" value="((((3 * @{Craft3-ranks}) + 3) - abs((3 * @{Craft3-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft3-name}" style="width:auto;" type="text" name="attr_Craft3-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft3}" type="number" name="attr_Craft3" value="(@{Craft3-ranks} + @{Craft3-class} + @{Craft3-ability} + @{Craft3-racial} + @{Craft3-feat} + @{Craft3-item} + @{Craft3-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft3-ranks}" type="number" name="attr_Craft3-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft3-class}" type="number" name="attr_Craft3-class" value="@{Craft3-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Craft3-ability}" name="attr_Craft3-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft3-ability}" type="number" name="attr_Craft3-ability-display" value="@{Craft3-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft3-racial}" type="number" name="attr_Craft3-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft3-feat}" type="number" name="attr_Craft3-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft3-item}" type="number" name="attr_Craft3-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Craft3-misc}" type="number" name="attr_Craft3-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Diplomacy-Check}" type="roll" value="@{character_name}'s Diplomacy check: [[1d20 + @{Diplomacy}]]" name="roll_Diplomacy-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy-cs}" type="checkbox" name="attr_Diplomacy-cs" value="((((3 * @{Diplomacy-ranks}) + 3) - abs((3 * @{Diplomacy-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Diplomacy</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy}" type="number" name="attr_Diplomacy" value="(@{Diplomacy-ranks} + @{Diplomacy-class} + @{Diplomacy-ability} + @{Diplomacy-racial} + @{Diplomacy-feat} + @{Diplomacy-item} + @{Diplomacy-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy-ranks}" type="number" name="attr_Diplomacy-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy-class}" type="number" name="attr_Diplomacy-class" value="@{Diplomacy-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Diplomacy-ability}" name="attr_Diplomacy-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}" selected>CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy-ability}" type="number" name="attr_Diplomacy-ability-display" value="@{Diplomacy-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy-racial}" type="number" name="attr_Diplomacy-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy-feat}" type="number" name="attr_Diplomacy-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy-item}" type="number" name="attr_Diplomacy-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Diplomacy-misc}" type="number" name="attr_Diplomacy-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Disable-Device-Check}" type="roll" value="@{character_name}'s Disable Device check: [[1d20 + @{Disable-Device}]]" name="roll_Disable-Device-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-cs}" type="checkbox" name="attr_Disable-Device-cs" value="((((3 * @{Disable-Device-ranks}) + 3) - abs((3 * @{Disable-Device-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Disable Device</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device}" type="number" name="attr_Disable-Device" value="(@{Disable-Device-ranks} + @{Disable-Device-class} + @{Disable-Device-ability} + @{Disable-Device-racial} + @{Disable-Device-feat} + @{Disable-Device-item} + @{Disable-Device-acp} + @{Disable-Device-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-ranks}" type="number" name="attr_Disable-Device-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-class}" type="number" name="attr_Disable-Device-class" value="@{Disable-Device-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Disable-Device-ability}" name="attr_Disable-Device-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}" selected>DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-ability}" type="number" name="attr_Disable-Device-ability-display" value="@{Disable-Device-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-racial}" type="number" name="attr_Disable-Device-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-feat}" type="number" name="attr_Disable-Device-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-item}" type="number" name="attr_Disable-Device-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-acp}" type="number" name="attr_Disable-Device-acp" value="@{acp}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-misc}" type="number" name="attr_Disable-Device-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Disguise-Check}" type="roll" value="@{character_name}'s Disguise check: [[1d20 + @{Disguise}]]" name="roll_Disguise-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disguise-cs}" type="checkbox" name="attr_Disguise-cs" value="((((3 * @{Disguise-ranks}) + 3) - abs((3 * @{Disguise-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Disguise</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disguise}" type="number" name="attr_Disguise" value="(@{Disguise-ranks} + @{Disguise-class} + @{Disguise-ability} + @{Disguise-racial} + @{Disguise-feat} + @{Disguise-item} + @{Disguise-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disguise-ranks}" type="number" name="attr_Disguise-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disguise-class}" type="number" name="attr_Disguise-class" value="@{Disguise-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Disguise-ability}" name="attr_Disguise-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}" selected>CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disguise-ability}" type="number" name="attr_Disguise-ability-display" value="@{Disguise-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disguise-racial}" type="number" name="attr_Disguise-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disguise-feat}" type="number" name="attr_Disguise-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disguise-item}" type="number" name="attr_Disguise-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Disguise-misc}" type="number" name="attr_Disguise-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Escape-Artist-Check}" type="roll" value="@{character_name}'s Escape Artist check: [[1d20 + @{Escape-Artist}]]" name="roll_Escape-Artist-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-cs}" type="checkbox" name="attr_Escape-Artist-cs" value="((((3 * @{Escape-Artist-ranks}) + 3) - abs((3 * @{Escape-Artist-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Escape Artist</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist}" type="number" name="attr_Escape-Artist" value="(@{Escape-Artist-ranks} + @{Escape-Artist-class} + @{Escape-Artist-ability} + @{Escape-Artist-racial} + @{Escape-Artist-feat} + @{Escape-Artist-item} + @{Escape-Artist-acp} + @{Escape-Artist-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-ranks}" type="number" name="attr_Escape-Artist-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-class}" type="number" name="attr_Escape-Artist-class" value="@{Escape-Artist-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Escape-Artist-ability}" name="attr_Escape-Artist-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}" selected>DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-ability}" type="number" name="attr_Escape-Artist-ability-display" value="@{Escape-Artist-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-racial}" type="number" name="attr_Escape-Artist-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-feat}" type="number" name="attr_Escape-Artist-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-item}" type="number" name="attr_Escape-Artist-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-acp}" type="number" name="attr_Escape-Artist-acp" value="@{acp}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-misc}" type="number" name="attr_Escape-Artist-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Fly-Check}" type="roll" value="@{character_name}'s Fly check: [[1d20 + @{Fly}]]" name="roll_Fly-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Fly-cs}" type="checkbox" name="attr_Fly-cs" value="((((3 * @{Fly-ranks}) + 3) - abs((3 * @{Fly-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Fly</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Fly}" type="number" name="attr_Fly" value="(@{Fly-ranks} + @{Fly-class} + @{Fly-ability} + @{Fly-racial} + @{Fly-feat} + @{Fly-item} + @{Fly-acp} + @{Fly-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Fly-ranks}" type="number" name="attr_Fly-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Fly-class}" type="number" name="attr_Fly-class" value="@{Fly-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Fly-ability}" name="attr_Fly-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}" selected>DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Fly-ability}" type="number" name="attr_Fly-ability-display" value="@{Fly-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Fly-racial}" type="number" name="attr_Fly-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Fly-feat}" type="number" name="attr_Fly-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Fly-item}" type="number" name="attr_Fly-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Fly-acp}" type="number" name="attr_Fly-acp" value="@{acp}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Fly-misc}" type="number" name="attr_Fly-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Handle-Animal-Check}" type="roll" value="@{character_name}'s Handle Animal check: [[1d20 + @{Handle-Animal}]]" name="roll_Handle-Animal-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-cs}" type="checkbox" name="attr_Handle-Animal-cs" value="((((3 * @{Handle-Animal-ranks}) + 3) - abs((3 * @{Handle-Animal-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Handle Animal</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal}" type="number" name="attr_Handle-Animal" value="(@{Handle-Animal-ranks} + @{Handle-Animal-class} + @{Handle-Animal-ability} + @{Handle-Animal-racial} + @{Handle-Animal-feat} + @{Handle-Animal-item} + @{Handle-Animal-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-ranks}" type="number" name="attr_Handle-Animal-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-class}" type="number" name="attr_Handle-Animal-class" value="@{Handle-Animal-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Handle-Animal-ability}" name="attr_Handle-Animal-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}" selected>CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-ability}" type="number" name="attr_Handle-Animal-ability-display" value="@{Handle-Animal-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-racial}" type="number" name="attr_Handle-Animal-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-feat}" type="number" name="attr_Handle-Animal-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-item}" type="number" name="attr_Handle-Animal-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-misc}" type="number" name="attr_Handle-Animal-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Heal-Check}" type="roll" value="@{character_name}'s Heal check: [[1d20 + @{Heal}]]" name="roll_Heal-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Heal-cs}" type="checkbox" name="attr_Heal-cs" value="((((3 * @{Heal-ranks}) + 3) - abs((3 * @{Heal-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Heal</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Heal}" type="number" name="attr_Heal" value="(@{Heal-ranks} + @{Heal-class} + @{Heal-ability} + @{Heal-racial} + @{Heal-feat} + @{Heal-item} + @{Heal-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Heal-ranks}" type="number" name="attr_Heal-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Heal-class}" type="number" name="attr_Heal-class" value="@{Heal-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Heal-ability}" name="attr_Heal-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}" selected>WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Heal-ability}" type="number" name="attr_Heal-ability-display" value="@{Heal-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Heal-racial}" type="number" name="attr_Heal-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Heal-feat}" type="number" name="attr_Heal-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Heal-item}" type="number" name="attr_Heal-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Heal-misc}" type="number" name="attr_Heal-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Intimidate-Check}" type="roll" value="@{character_name}'s Intimidate check: [[1d20 + @{Intimidate}]]" name="roll_Intimidate-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Intimidate-cs}" type="checkbox" name="attr_Intimidate-cs" value="((((3 * @{Intimidate-ranks}) + 3) - abs((3 * @{Intimidate-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Intimidate</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Intimidate}" type="number" name="attr_Intimidate" value="(@{Intimidate-ranks} + @{Intimidate-class} + @{Intimidate-ability} + @{Intimidate-racial} + @{Intimidate-feat} + @{Intimidate-item} + @{Intimidate-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Intimidate-ranks}" type="number" name="attr_Intimidate-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Intimidate-class}" type="number" name="attr_Intimidate-class" value="@{Intimidate-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Intimidate-ability}" name="attr_Intimidate-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}" selected>CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Intimidate-ability}" type="number" name="attr_Intimidate-ability-display" value="@{Intimidate-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Intimidate-racial}" type="number" name="attr_Intimidate-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Intimidate-feat}" type="number" name="attr_Intimidate-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Intimidate-item}" type="number" name="attr_Intimidate-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Intimidate-misc}" type="number" name="attr_Intimidate-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Arcana-Check}" type="roll" value="@{character_name}'s Knowledge (Arcana) check: [[1d20 + @{Knowledge-Arcana}]]" name="roll_Knowledge-Arcana-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-cs}" type="checkbox" name="attr_Knowledge-Arcana-cs" value="((((3 * @{Knowledge-Arcana-ranks}) + 3) - abs((3 * @{Knowledge-Arcana-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Knowledge (Arcana)</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana}" type="number" name="attr_Knowledge-Arcana" value="(@{Knowledge-Arcana-ranks} + @{Knowledge-Arcana-class} + @{Knowledge-Arcana-ability} + @{Knowledge-Arcana-racial} + @{Knowledge-Arcana-feat} + @{Knowledge-Arcana-item} + @{Knowledge-Arcana-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-ranks}" type="number" name="attr_Knowledge-Arcana-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-class}" type="number" name="attr_Knowledge-Arcana-class" value="@{Knowledge-Arcana-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Knowledge-Arcana-ability}" name="attr_Knowledge-Arcana-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-ability}" type="number" name="attr_Knowledge-Arcana-ability-display" value="@{Knowledge-Arcana-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-racial}" type="number" name="attr_Knowledge-Arcana-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-feat}" type="number" name="attr_Knowledge-Arcana-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-item}" type="number" name="attr_Knowledge-Arcana-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-misc}" type="number" name="attr_Knowledge-Arcana-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Dungeoneering-Check}" type="roll" value="@{character_name}'s Knowledge (Dungeoneering) check: [[1d20 + @{Knowledge-Dungeoneering}]]" name="roll_Knowledge-Dungeoneering-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-cs}" type="checkbox" name="attr_Knowledge-Dungeoneering-cs" value="((((3 * @{Knowledge-Dungeoneering-ranks}) + 3) - abs((3 * @{Knowledge-Dungeoneering-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Knowledge (Dungeoneering)</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering}" type="number" name="attr_Knowledge-Dungeoneering" value="(@{Knowledge-Dungeoneering-ranks} + @{Knowledge-Dungeoneering-class} + @{Knowledge-Dungeoneering-ability} + @{Knowledge-Dungeoneering-racial} + @{Knowledge-Dungeoneering-feat} + @{Knowledge-Dungeoneering-item} + @{Knowledge-Dungeoneering-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-ranks}" type="number" name="attr_Knowledge-Dungeoneering-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-class}" type="number" name="attr_Knowledge-Dungeoneering-class" value="@{Knowledge-Dungeoneering-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Knowledge-Dungeoneering-ability}" name="attr_Knowledge-Dungeoneering-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-ability}" type="number" name="attr_Knowledge-Dungeoneering-ability-display" value="@{Knowledge-Dungeoneering-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-racial}" type="number" name="attr_Knowledge-Dungeoneering-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-feat}" type="number" name="attr_Knowledge-Dungeoneering-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-item}" type="number" name="attr_Knowledge-Dungeoneering-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-misc}" type="number" name="attr_Knowledge-Dungeoneering-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Engineering-Check}" type="roll" value="@{character_name}'s Knowledge (Engineering) check: [[1d20 + @{Knowledge-Engineering}]]" name="roll_Knowledge-Engineering-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-cs}" type="checkbox" name="attr_Knowledge-Engineering-cs" value="((((3 * @{Knowledge-Engineering-ranks}) + 3) - abs((3 * @{Knowledge-Engineering-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Knowledge (Engineering)</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering}" type="number" name="attr_Knowledge-Engineering" value="(@{Knowledge-Engineering-ranks} + @{Knowledge-Engineering-class} + @{Knowledge-Engineering-ability} + @{Knowledge-Engineering-racial} + @{Knowledge-Engineering-feat} + @{Knowledge-Engineering-item} + @{Knowledge-Engineering-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-ranks}" type="number" name="attr_Knowledge-Engineering-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-class}" type="number" name="attr_Knowledge-Engineering-class" value="@{Knowledge-Engineering-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Knowledge-Engineering-ability}" name="attr_Knowledge-Engineering-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-ability}" type="number" name="attr_Knowledge-Engineering-ability-display" value="@{Knowledge-Engineering-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-racial}" type="number" name="attr_Knowledge-Engineering-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-feat}" type="number" name="attr_Knowledge-Engineering-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-item}" type="number" name="attr_Knowledge-Engineering-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-misc}" type="number" name="attr_Knowledge-Engineering-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Geography-Check}" type="roll" value="@{character_name}'s Knowledge (Geography) check: [[1d20 + @{Knowledge-Geography}]]" name="roll_Knowledge-Geography-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-cs}" type="checkbox" name="attr_Knowledge-Geography-cs" value="((((3 * @{Knowledge-Geography-ranks}) + 3) - abs((3 * @{Knowledge-Geography-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Knowledge (Geography)</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography}" type="number" name="attr_Knowledge-Geography" value="(@{Knowledge-Geography-ranks} + @{Knowledge-Geography-class} + @{Knowledge-Geography-ability} + @{Knowledge-Geography-racial} + @{Knowledge-Geography-feat} + @{Knowledge-Geography-item} + @{Knowledge-Geography-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-ranks}" type="number" name="attr_Knowledge-Geography-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-class}" type="number" name="attr_Knowledge-Geography-class" value="@{Knowledge-Geography-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Knowledge-Geography-ability}" name="attr_Knowledge-Geography-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-ability}" type="number" name="attr_Knowledge-Geography-ability-display" value="@{Knowledge-Geography-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-racial}" type="number" name="attr_Knowledge-Geography-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-feat}" type="number" name="attr_Knowledge-Geography-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-item}" type="number" name="attr_Knowledge-Geography-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-misc}" type="number" name="attr_Knowledge-Geography-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-History-Check}" type="roll" value="@{character_name}'s Knowledge (History) check: [[1d20 + @{Knowledge-History}]]" name="roll_Knowledge-History-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-cs}" type="checkbox" name="attr_Knowledge-History-cs" value="((((3 * @{Knowledge-History-ranks}) + 3) - abs((3 * @{Knowledge-History-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Knowledge (History)</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History}" type="number" name="attr_Knowledge-History" value="(@{Knowledge-History-ranks} + @{Knowledge-History-class} + @{Knowledge-History-ability} + @{Knowledge-History-racial} + @{Knowledge-History-feat} + @{Knowledge-History-item} + @{Knowledge-History-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-ranks}" type="number" name="attr_Knowledge-History-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-class}" type="number" name="attr_Knowledge-History-class" value="@{Knowledge-History-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Knowledge-History-ability}" name="attr_Knowledge-History-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-ability}" type="number" name="attr_Knowledge-History-ability-display" value="@{Knowledge-History-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-racial}" type="number" name="attr_Knowledge-History-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-feat}" type="number" name="attr_Knowledge-History-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-item}" type="number" name="attr_Knowledge-History-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-misc}" type="number" name="attr_Knowledge-History-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Local-Check}" type="roll" value="@{character_name}'s Knowledge (Local) check: [[1d20 + @{Knowledge-Local}]]" name="roll_Knowledge-Local-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-cs}" type="checkbox" name="attr_Knowledge-Local-cs" value="((((3 * @{Knowledge-Local-ranks}) + 3) - abs((3 * @{Knowledge-Local-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Knowledge (Local)</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local}" type="number" name="attr_Knowledge-Local" value="(@{Knowledge-Local-ranks} + @{Knowledge-Local-class} + @{Knowledge-Local-ability} + @{Knowledge-Local-racial} + @{Knowledge-Local-feat} + @{Knowledge-Local-item} + @{Knowledge-Local-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-ranks}" type="number" name="attr_Knowledge-Local-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-class}" type="number" name="attr_Knowledge-Local-class" value="@{Knowledge-Local-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Knowledge-Local-ability}" name="attr_Knowledge-Local-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-ability}" type="number" name="attr_Knowledge-Local-ability-display" value="@{Knowledge-Local-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-racial}" type="number" name="attr_Knowledge-Local-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-feat}" type="number" name="attr_Knowledge-Local-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-item}" type="number" name="attr_Knowledge-Local-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-misc}" type="number" name="attr_Knowledge-Local-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Nature-Check}" type="roll" value="@{character_name}'s Knowledge (Nature) check: [[1d20 + @{Knowledge-Nature}]]" name="roll_Knowledge-Nature-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-cs}" type="checkbox" name="attr_Knowledge-Nature-cs" value="((((3 * @{Knowledge-Nature-ranks}) + 3) - abs((3 * @{Knowledge-Nature-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Knowledge (Nature)</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature}" type="number" name="attr_Knowledge-Nature" value="(@{Knowledge-Nature-ranks} + @{Knowledge-Nature-class} + @{Knowledge-Nature-ability} + @{Knowledge-Nature-racial} + @{Knowledge-Nature-feat} + @{Knowledge-Nature-item} + @{Knowledge-Nature-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-ranks}" type="number" name="attr_Knowledge-Nature-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-class}" type="number" name="attr_Knowledge-Nature-class" value="@{Knowledge-Nature-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Knowledge-Nature-ability}" name="attr_Knowledge-Nature-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-ability}" type="number" name="attr_Knowledge-Nature-ability-display" value="@{Knowledge-Nature-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-racial}" type="number" name="attr_Knowledge-Nature-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-feat}" type="number" name="attr_Knowledge-Nature-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-item}" type="number" name="attr_Knowledge-Nature-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-misc}" type="number" name="attr_Knowledge-Nature-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Nobility-Check}" type="roll" value="@{character_name}'s Knowledge (Nobility) check: [[1d20 + @{Knowledge-Nobility}]]" name="roll_Knowledge-Nobility-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-cs}" type="checkbox" name="attr_Knowledge-Nobility-cs" value="((((3 * @{Knowledge-Nobility-ranks}) + 3) - abs((3 * @{Knowledge-Nobility-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Knowledge (Nobility)</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility}" type="number" name="attr_Knowledge-Nobility" value="(@{Knowledge-Nobility-ranks} + @{Knowledge-Nobility-class} + @{Knowledge-Nobility-ability} + @{Knowledge-Nobility-racial} + @{Knowledge-Nobility-feat} + @{Knowledge-Nobility-item} + @{Knowledge-Nobility-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-ranks}" type="number" name="attr_Knowledge-Nobility-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-class}" type="number" name="attr_Knowledge-Nobility-class" value="@{Knowledge-Nobility-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Knowledge-Nobility-ability}" name="attr_Knowledge-Nobility-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-ability}" type="number" name="attr_Knowledge-Nobility-ability-display" value="@{Knowledge-Nobility-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-racial}" type="number" name="attr_Knowledge-Nobility-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-feat}" type="number" name="attr_Knowledge-Nobility-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-item}" type="number" name="attr_Knowledge-Nobility-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-misc}" type="number" name="attr_Knowledge-Nobility-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Planes-Check}" type="roll" value="@{character_name}'s Knowledge (Planes) check: [[1d20 + @{Knowledge-Planes}]]" name="roll_Knowledge-Planes-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-cs}" type="checkbox" name="attr_Knowledge-Planes-cs" value="((((3 * @{Knowledge-Planes-ranks}) + 3) - abs((3 * @{Knowledge-Planes-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Knowledge (Planes)</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes}" type="number" name="attr_Knowledge-Planes" value="(@{Knowledge-Planes-ranks} + @{Knowledge-Planes-class} + @{Knowledge-Planes-ability} + @{Knowledge-Planes-racial} + @{Knowledge-Planes-feat} + @{Knowledge-Planes-item} + @{Knowledge-Planes-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-ranks}" type="number" name="attr_Knowledge-Planes-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-class}" type="number" name="attr_Knowledge-Planes-class" value="@{Knowledge-Planes-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Knowledge-Planes-ability}" name="attr_Knowledge-Planes-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-ability}" type="number" name="attr_Knowledge-Planes-ability-display" value="@{Knowledge-Planes-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-racial}" type="number" name="attr_Knowledge-Planes-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-feat}" type="number" name="attr_Knowledge-Planes-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-item}" type="number" name="attr_Knowledge-Planes-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-misc}" type="number" name="attr_Knowledge-Planes-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Religion-Check}" type="roll" value="@{character_name}'s Knowledge (Religion) check: [[1d20 + @{Knowledge-Religion}]]" name="roll_Knowledge-Religion-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-cs}" type="checkbox" name="attr_Knowledge-Religion-cs" value="((((3 * @{Knowledge-Religion-ranks}) + 3) - abs((3 * @{Knowledge-Religion-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Knowledge (Religion)</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion}" type="number" name="attr_Knowledge-Religion" value="(@{Knowledge-Religion-ranks} + @{Knowledge-Religion-class} + @{Knowledge-Religion-ability} + @{Knowledge-Religion-racial} + @{Knowledge-Religion-feat} + @{Knowledge-Religion-item} + @{Knowledge-Religion-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-ranks}" type="number" name="attr_Knowledge-Religion-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-class}" type="number" name="attr_Knowledge-Religion-class" value="@{Knowledge-Religion-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Knowledge-Religion-ability}" name="attr_Knowledge-Religion-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-ability}" type="number" name="attr_Knowledge-Religion-ability-display" value="@{Knowledge-Religion-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-racial}" type="number" name="attr_Knowledge-Religion-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-feat}" type="number" name="attr_Knowledge-Religion-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-item}" type="number" name="attr_Knowledge-Religion-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-misc}" type="number" name="attr_Knowledge-Religion-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Linguistics-Check}" type="roll" value="@{character_name}'s Linguistics check: [[1d20 + @{Linguistics}]]" name="roll_Linguistics-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Linguistics-cs}" type="checkbox" name="attr_Linguistics-cs" value="((((3 * @{Linguistics-ranks}) + 3) - abs((3 * @{Linguistics-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Linguistics</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Linguistics}" type="number" name="attr_Linguistics" value="(@{Linguistics-ranks} + @{Linguistics-class} + @{Linguistics-ability} + @{Linguistics-racial} + @{Linguistics-feat} + @{Linguistics-item} + @{Linguistics-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Linguistics-ranks}" type="number" name="attr_Linguistics-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Linguistics-class}" type="number" name="attr_Linguistics-class" value="@{Linguistics-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Linguistics-ability}" name="attr_Linguistics-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Linguistics-ability}" type="number" name="attr_Linguistics-ability-display" value="@{Linguistics-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Linguistics-racial}" type="number" name="attr_Linguistics-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Linguistics-feat}" type="number" name="attr_Linguistics-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Linguistics-item}" type="number" name="attr_Linguistics-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Linguistics-misc}" type="number" name="attr_Linguistics-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perception-Check}" type="roll" value="@{character_name}'s Perception check: [[1d20 + @{Perception}]]" name="roll_Perception-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perception-cs}" type="checkbox" name="attr_Perception-cs" value="((((3 * @{Perception-ranks}) + 3) - abs((3 * @{Perception-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Perception</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perception}" type="number" name="attr_Perception" value="(@{Perception-ranks} + @{Perception-class} + @{Perception-ability} + @{Perception-racial} + @{Perception-feat} + @{Perception-item} + @{Perception-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perception-ranks}" type="number" name="attr_Perception-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perception-class}" type="number" name="attr_Perception-class" value="@{Perception-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Perception-ability}" name="attr_Perception-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}" selected>WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perception-ability}" type="number" name="attr_Perception-ability-display" value="@{Perception-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perception-racial}" type="number" name="attr_Perception-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perception-feat}" type="number" name="attr_Perception-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perception-item}" type="number" name="attr_Perception-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perception-misc}" type="number" name="attr_Perception-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform-Check}" type="roll" value="@{character_name}'s Perform: @{Perform-name} check: [[1d20 + @{Perform}]]" name="roll_Perform-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform-cs}" type="checkbox" name="attr_Perform-cs" value="((((3 * @{Perform-ranks}) + 3) - abs((3 * @{Perform-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform-name}" style="width:auto;" type="text" name="attr_Perform-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform}" type="number" name="attr_Perform" value="(@{Perform-ranks} + @{Perform-class} + @{Perform-ability} + @{Perform-racial} + @{Perform-feat} + @{Perform-item} + @{Perform-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform-ranks}" type="number" name="attr_Perform-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform-class}" type="number" name="attr_Perform-class" value="@{Perform-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Perform-ability}" name="attr_Perform-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}" selected>CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform-ability}" type="number" name="attr_Perform-ability-display" value="@{Perform-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform-racial}" type="number" name="attr_Perform-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform-feat}" type="number" name="attr_Perform-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform-item}" type="number" name="attr_Perform-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform-misc}" type="number" name="attr_Perform-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform2-Check}" type="roll" value="@{character_name}'s Perform: @{Perform2-name} check: [[1d20 + @{Perform2}]]" name="roll_Perform2-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform2-cs}" type="checkbox" name="attr_Perform2-cs" value="((((3 * @{Perform2-ranks}) + 3) - abs((3 * @{Perform2-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform2-name}" style="width:auto;" type="text" name="attr_Perform2-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform2}" type="number" name="attr_Perform2" value="(@{Perform2-ranks} + @{Perform2-class} + @{Perform2-ability} + @{Perform2-racial} + @{Perform2-feat} + @{Perform2-item} + @{Perform2-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform2-ranks}" type="number" name="attr_Perform2-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform2-class}" type="number" name="attr_Perform2-class" value="@{Perform2-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Perform2-ability}" name="attr_Perform2-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}" selected>CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform2-ability}" type="number" name="attr_Perform2-ability-display" value="@{Perform2-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform2-racial}" type="number" name="attr_Perform2-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform2-feat}" type="number" name="attr_Perform2-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform2-item}" type="number" name="attr_Perform2-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform2-misc}" type="number" name="attr_Perform2-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform3-Check}" type="roll" value="@{character_name}'s Perform: @{Perform3-name} check: [[1d20 + @{Perform3}]]" name="roll_Perform3-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform3-cs}" type="checkbox" name="attr_Perform3-cs" value="((((3 * @{Perform3-ranks}) + 3) - abs((3 * @{Perform3-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform3-name}" style="width:auto;" type="text" name="attr_Perform3-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform3}" type="number" name="attr_Perform3" value="(@{Perform3-ranks} + @{Perform3-class} + @{Perform3-ability} + @{Perform3-racial} + @{Perform3-feat} + @{Perform3-item} + @{Perform3-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform3-ranks}" type="number" name="attr_Perform3-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform3-class}" type="number" name="attr_Perform3-class" value="@{Perform3-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Perform3-ability}" name="attr_Perform3-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}" selected>CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform3-ability}" type="number" name="attr_Perform3-ability-display" value="@{Perform3-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform3-racial}" type="number" name="attr_Perform3-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform3-feat}" type="number" name="attr_Perform3-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform3-item}" type="number" name="attr_Perform3-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Perform3-misc}" type="number" name="attr_Perform3-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession-Check}" type="roll" value="@{character_name}'s Profession: @{Profession-name} check: [[1d20 + @{Profession}]]" name="roll_Profession-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession-cs}" type="checkbox" name="attr_Profession-cs" value="((((3 * @{Profession-ranks}) + 3) - abs((3 * @{Profession-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession-name}" style="width:auto;" type="text" name="attr_Profession-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession}" type="number" name="attr_Profession" value="(@{Profession-ranks} + @{Profession-class} + @{Profession-ability} + @{Profession-racial} + @{Profession-feat} + @{Profession-item} + @{Profession-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession-ranks}" type="number" name="attr_Profession-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession-class}" type="number" name="attr_Profession-class" value="@{Profession-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Profession-ability}" name="attr_Profession-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}" selected>WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession-ability}" type="number" name="attr_Profession-ability-display" value="@{Profession-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession-racial}" type="number" name="attr_Profession-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession-feat}" type="number" name="attr_Profession-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession-item}" type="number" name="attr_Profession-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession-misc}" type="number" name="attr_Profession-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession2-Check}" type="roll" value="@{character_name}'s Profession: @{Profession2-name} check: [[1d20 + @{Profession2}]]" name="roll_Profession2-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession2-cs}" type="checkbox" name="attr_Profession2-cs" value="((((3 * @{Profession2-ranks}) + 3) - abs((3 * @{Profession2-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession2-name}" style="width:auto;" type="text" name="attr_Profession2-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession2}" type="number" name="attr_Profession2" value="(@{Profession2-ranks} + @{Profession2-class} + @{Profession2-ability} + @{Profession2-racial} + @{Profession2-feat} + @{Profession2-item} + @{Profession2-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession2-ranks}" type="number" name="attr_Profession2-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession2-class}" type="number" name="attr_Profession2-class" value="@{Profession2-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Profession2-ability}" name="attr_Profession2-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}" selected>WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession2-ability}" type="number" name="attr_Profession2-ability-display" value="@{Profession2-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession2-racial}" type="number" name="attr_Profession2-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession2-feat}" type="number" name="attr_Profession2-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession2-item}" type="number" name="attr_Profession2-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession2-misc}" type="number" name="attr_Profession2-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession3-Check}" type="roll" value="@{character_name}'s Profession: @{Profession3-name} check: [[1d20 + @{Profession3}]]" name="roll_Profession3-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession3-cs}" type="checkbox" name="attr_Profession3-cs" value="((((3 * @{Profession3-ranks}) + 3) - abs((3 * @{Profession3-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession3-name}" style="width:auto;" type="text" name="attr_Profession3-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession3}" type="number" name="attr_Profession3" value="(@{Profession3-ranks} + @{Profession3-class} + @{Profession3-ability} + @{Profession3-racial} + @{Profession3-feat} + @{Profession3-item} + @{Profession3-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession3-ranks}" type="number" name="attr_Profession3-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession3-class}" type="number" name="attr_Profession3-class" value="@{Profession3-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Profession3-ability}" name="attr_Profession3-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}" selected>WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession3-ability}" type="number" name="attr_Profession3-ability-display" value="@{Profession3-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession3-racial}" type="number" name="attr_Profession3-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession3-feat}" type="number" name="attr_Profession3-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession3-item}" type="number" name="attr_Profession3-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Profession3-misc}" type="number" name="attr_Profession3-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Ride-Check}" type="roll" value="@{character_name}'s Ride check: [[1d20 + @{Ride}]]" name="roll_Ride-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Ride-cs}" type="checkbox" name="attr_Ride-cs" value="((((3 * @{Ride-ranks}) + 3) - abs((3 * @{Ride-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Ride</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Ride}" type="number" name="attr_Ride" value="(@{Ride-ranks} + @{Ride-class} + @{Ride-ability} + @{Ride-racial} + @{Ride-feat} + @{Ride-item} + @{Ride-acp} + @{Ride-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Ride-ranks}" type="number" name="attr_Ride-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Ride-class}" type="number" name="attr_Ride-class" value="@{Ride-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Ride-ability}" name="attr_Ride-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}" selected>DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Ride-ability}" type="number" name="attr_Ride-ability-display" value="@{Ride-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Ride-racial}" type="number" name="attr_Ride-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Ride-feat}" type="number" name="attr_Ride-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Ride-item}" type="number" name="attr_Ride-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Ride-acp}" type="number" name="attr_Ride-acp" value="@{acp}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Ride-misc}" type="number" name="attr_Ride-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Sense-Motive-Check}" type="roll" value="@{character_name}'s Sense Motive check: [[1d20 + @{Sense-Motive}]]" name="roll_Sense-Motive-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-cs}" type="checkbox" name="attr_Sense-Motive-cs" value="((((3 * @{Sense-Motive-ranks}) + 3) - abs((3 * @{Sense-Motive-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Sense Motive</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive}" type="number" name="attr_Sense-Motive" value="(@{Sense-Motive-ranks} + @{Sense-Motive-class} + @{Sense-Motive-ability} + @{Sense-Motive-racial} + @{Sense-Motive-feat} + @{Sense-Motive-item} + @{Sense-Motive-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-ranks}" type="number" name="attr_Sense-Motive-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-class}" type="number" name="attr_Sense-Motive-class" value="@{Sense-Motive-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Sense-Motive-ability}" name="attr_Sense-Motive-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}" selected>WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-ability}" type="number" name="attr_Sense-Motive-ability-display" value="@{Sense-Motive-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-racial}" type="number" name="attr_Sense-Motive-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-feat}" type="number" name="attr_Sense-Motive-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-item}" type="number" name="attr_Sense-Motive-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-misc}" type="number" name="attr_Sense-Motive-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Sleight-of-Hand-Check}" type="roll" value="@{character_name}'s Sleight of Hand check: [[1d20 + @{Sleight-of-Hand}]]" name="roll_Sleight-of-Hand-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-cs}" type="checkbox" name="attr_Sleight-of-Hand-cs" value="((((3 * @{Sleight-of-Hand-ranks}) + 3) - abs((3 * @{Sleight-of-Hand-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Sleight of Hand</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand}" type="number" name="attr_Sleight-of-Hand" value="(@{Sleight-of-Hand-ranks} + @{Sleight-of-Hand-class} + @{Sleight-of-Hand-ability} + @{Sleight-of-Hand-racial} + @{Sleight-of-Hand-feat} + @{Sleight-of-Hand-item} + @{Sleight-of-Hand-acp} + @{Sleight-of-Hand-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-ranks}" type="number" name="attr_Sleight-of-Hand-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-class}" type="number" name="attr_Sleight-of-Hand-class" value="@{Sleight-of-Hand-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Sleight-of-Hand-ability}" name="attr_Sleight-of-Hand-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}" selected>DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-ability}" type="number" name="attr_Sleight-of-Hand-ability-display" value="@{Sleight-of-Hand-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-racial}" type="number" name="attr_Sleight-of-Hand-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-feat}" type="number" name="attr_Sleight-of-Hand-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-item}" type="number" name="attr_Sleight-of-Hand-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-acp}" type="number" name="attr_Sleight-of-Hand-acp" value="@{acp}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-misc}" type="number" name="attr_Sleight-of-Hand-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Spellcraft-Check}" type="roll" value="@{character_name}'s Spellcraft check: [[1d20 + @{Spellcraft}]]" name="roll_Spellcraft-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft-cs}" type="checkbox" name="attr_Spellcraft-cs" value="((((3 * @{Spellcraft-ranks}) + 3) - abs((3 * @{Spellcraft-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Spellcraft</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft}" type="number" name="attr_Spellcraft" value="(@{Spellcraft-ranks} + @{Spellcraft-class} + @{Spellcraft-ability} + @{Spellcraft-racial} + @{Spellcraft-feat} + @{Spellcraft-item} + @{Spellcraft-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft-ranks}" type="number" name="attr_Spellcraft-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft-class}" type="number" name="attr_Spellcraft-class" value="@{Spellcraft-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Spellcraft-ability}" name="attr_Spellcraft-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}" selected>INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft-ability}" type="number" name="attr_Spellcraft-ability-display" value="@{Spellcraft-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft-racial}" type="number" name="attr_Spellcraft-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft-feat}" type="number" name="attr_Spellcraft-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft-item}" type="number" name="attr_Spellcraft-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Spellcraft-misc}" type="number" name="attr_Spellcraft-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Stealth-Check}" type="roll" value="@{character_name}'s Stealth check: [[1d20 + @{Stealth}]]" name="roll_Stealth-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Stealth-cs}" type="checkbox" name="attr_Stealth-cs" value="((((3 * @{Stealth-ranks}) + 3) - abs((3 * @{Stealth-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Stealth</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Stealth}" type="number" name="attr_Stealth" value="(@{Stealth-ranks} + @{Stealth-class} + @{Stealth-ability} + @{Stealth-racial} + @{Stealth-feat} + @{Stealth-item} + @{Stealth-acp} + @{Stealth-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Stealth-ranks}" type="number" name="attr_Stealth-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Stealth-class}" type="number" name="attr_Stealth-class" value="@{Stealth-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Stealth-ability}" name="attr_Stealth-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}" selected>DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Stealth-ability}" type="number" name="attr_Stealth-ability-display" value="@{Stealth-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Stealth-racial}" type="number" name="attr_Stealth-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Stealth-feat}" type="number" name="attr_Stealth-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Stealth-item}" type="number" name="attr_Stealth-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Stealth-acp}" type="number" name="attr_Stealth-acp" value="@{acp}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Stealth-misc}" type="number" name="attr_Stealth-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Survival-Check}" type="roll" value="@{character_name}'s Survival check: [[1d20 + @{Survival}]]" name="roll_Survival-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Survival-cs}" type="checkbox" name="attr_Survival-cs" value="((((3 * @{Survival-ranks}) + 3) - abs((3 * @{Survival-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Survival</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Survival}" type="number" name="attr_Survival" value="(@{Survival-ranks} + @{Survival-class} + @{Survival-ability} + @{Survival-racial} + @{Survival-feat} + @{Survival-item} + @{Survival-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Survival-ranks}" type="number" name="attr_Survival-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Survival-class}" type="number" name="attr_Survival-class" value="@{Survival-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Survival-ability}" name="attr_Survival-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}" selected>WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Survival-ability}" type="number" name="attr_Survival-ability-display" value="@{Survival-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Survival-racial}" type="number" name="attr_Survival-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Survival-feat}" type="number" name="attr_Survival-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Survival-item}" type="number" name="attr_Survival-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Survival-misc}" type="number" name="attr_Survival-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Swim-Check}" type="roll" value="@{character_name}'s Swim check: [[1d20 + @{Swim}]]" name="roll_Swim-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Swim-cs}" type="checkbox" name="attr_Swim-cs" value="((((3 * @{Swim-ranks}) + 3) - abs((3 * @{Swim-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center">*</span>
+				<span class="sheet-table-data sheet-left">Swim</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Swim}" type="number" name="attr_Swim" value="(@{Swim-ranks} + @{Swim-class} + @{Swim-ability} + @{Swim-racial} + @{Swim-feat} + @{Swim-item} + @{Swim-acp} + @{Swim-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Swim-ranks}" type="number" name="attr_Swim-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Swim-class}" type="number" name="attr_Swim-class" value="@{Swim-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Swim-ability}" name="attr_Swim-ability">
+						<option value="@{STR-mod}" selected>STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Swim-ability}" type="number" name="attr_Swim-ability-display" value="@{Swim-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Swim-racial}" type="number" name="attr_Swim-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Swim-feat}" type="number" name="attr_Swim-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Swim-item}" type="number" name="attr_Swim-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Swim-acp}" type="number" name="attr_Swim-acp" value="@{acp}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Swim-misc}" type="number" name="attr_Swim-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Use-Magic-Device-Check}" type="roll" value="@{character_name}'s Use Magic Device check: [[1d20 + @{Use-Magic-Device}]]" name="roll_Use-Magic-Device-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-cs}" type="checkbox" name="attr_Use-Magic-Device-cs" value="((((3 * @{Use-Magic-Device-ranks}) + 3) - abs((3 * @{Use-Magic-Device-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left">Use Magic Device</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device}" type="number" name="attr_Use-Magic-Device" value="(@{Use-Magic-Device-ranks} + @{Use-Magic-Device-class} + @{Use-Magic-Device-ability} + @{Use-Magic-Device-racial} + @{Use-Magic-Device-feat} + @{Use-Magic-Device-item} + @{Use-Magic-Device-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-ranks}" type="number" name="attr_Use-Magic-Device-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-class}" type="number" name="attr_Use-Magic-Device-class" value="@{Use-Magic-Device-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Use-Magic-Device-ability}" name="attr_Use-Magic-Device-ability">
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}" selected>CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-ability}" type="number" name="attr_Use-Magic-Device-ability-display" value="@{Use-Magic-Device-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-racial}" type="number" name="attr_Use-Magic-Device-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-feat}" type="number" name="attr_Use-Magic-Device-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-item}" type="number" name="attr_Use-Magic-Device-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><b>N/A</b></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-misc}" type="number" name="attr_Use-Magic-Device-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-0-Check}" type="roll" value="@{character_name}'s @{Misc-Skill-0-name} check: [[1d20 + @{Misc-Skill-0}]]" name="roll_Misc-Skill-0-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-cs}" type="checkbox" name="attr_Misc-Skill-0-cs" value="((((3 * @{Misc-Skill-0-ranks}) + 3) - abs((3 * @{Misc-Skill-0-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-0-name}" name="attr_Misc-Skill-0-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0}" type="number" name="attr_Misc-Skill-0" value="(@{Misc-Skill-0-ranks} + @{Misc-Skill-0-class} + @{Misc-Skill-0-ability} + @{Misc-Skill-0-racial} + @{Misc-Skill-0-feat} + @{Misc-Skill-0-item} + @{Misc-Skill-0-acp} + @{Misc-Skill-0-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-ranks}" type="number" name="attr_Misc-Skill-0-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-class}" type="number" name="attr_Misc-Skill-0-class" value="@{Misc-Skill-0-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Misc-Skill-0-ability}" name="attr_Misc-Skill-0-ability">
+						<option value="0">None</option>
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-ability}" type="number" name="attr_Misc-Skill-0-ability-display" value="@{Misc-Skill-0-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-racial}" type="number" name="attr_Misc-Skill-0-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-feat}" type="number" name="attr_Misc-Skill-0-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-item}" type="number" name="attr_Misc-Skill-0-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-acp}" type="checkbox" name="attr_Misc-Skill-0-acp" value="@{acp}"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-misc}" type="number" name="attr_Misc-Skill-0-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-1-Check}" type="roll" value="@{character_name}'s @{Misc-Skill-1-name} check: [[1d20 + @{Misc-Skill-1}]]" name="roll_Misc-Skill-1-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-cs}" type="checkbox" name="attr_Misc-Skill-1-cs" value="((((3 * @{Misc-Skill-1-ranks}) + 3) - abs((3 * @{Misc-Skill-1-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-1-name}" name="attr_Misc-Skill-1-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1}" type="number" name="attr_Misc-Skill-1" value="(@{Misc-Skill-1-ranks} + @{Misc-Skill-1-class} + @{Misc-Skill-1-ability} + @{Misc-Skill-1-racial} + @{Misc-Skill-1-feat} + @{Misc-Skill-1-item} + @{Misc-Skill-1-acp} + @{Misc-Skill-1-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-ranks}" type="number" name="attr_Misc-Skill-1-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-class}" type="number" name="attr_Misc-Skill-1-class" value="@{Misc-Skill-1-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Misc-Skill-1-ability}" name="attr_Misc-Skill-1-ability">
+						<option value="0">None</option>
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-ability}" type="number" name="attr_Misc-Skill-1-ability-display" value="@{Misc-Skill-1-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-racial}" type="number" name="attr_Misc-Skill-1-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-feat}" type="number" name="attr_Misc-Skill-1-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-item}" type="number" name="attr_Misc-Skill-1-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-acp}" type="checkbox" name="attr_Misc-Skill-1-acp" value="@{acp}"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-misc}" type="number" name="attr_Misc-Skill-1-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-2-Check}" type="roll" value="@{character_name}'s @{Misc-Skill-2-name} check: [[1d20 + @{Misc-Skill-2}]]" name="roll_Misc-Skill-2-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-cs}" type="checkbox" name="attr_Misc-Skill-2-cs" value="((((3 * @{Misc-Skill-2-ranks}) + 3) - abs((3 * @{Misc-Skill-2-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-2-name}" name="attr_Misc-Skill-2-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2}" type="number" name="attr_Misc-Skill-2" value="(@{Misc-Skill-2-ranks} + @{Misc-Skill-2-class} + @{Misc-Skill-2-ability} + @{Misc-Skill-2-racial} + @{Misc-Skill-2-feat} + @{Misc-Skill-2-item} + @{Misc-Skill-2-acp} + @{Misc-Skill-2-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-ranks}" type="number" name="attr_Misc-Skill-2-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-class}" type="number" name="attr_Misc-Skill-2-class" value="@{Misc-Skill-2-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Misc-Skill-2-ability}" name="attr_Misc-Skill-2-ability">
+						<option value="0">None</option>
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-ability}" type="number" name="attr_Misc-Skill-2-ability-display" value="@{Misc-Skill-2-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-racial}" type="number" name="attr_Misc-Skill-2-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-feat}" type="number" name="attr_Misc-Skill-2-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-item}" type="number" name="attr_Misc-Skill-2-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-acp}" type="checkbox" name="attr_Misc-Skill-2-acp" value="@{acp}"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-misc}" type="number" name="attr_Misc-Skill-2-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-3-Check}" type="roll" value="@{character_name}'s @{Misc-Skill-3-name} check: [[1d20 + @{Misc-Skill-3}]]" name="roll_Misc-Skill-3-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-cs}" type="checkbox" name="attr_Misc-Skill-3-cs" value="((((3 * @{Misc-Skill-3-ranks}) + 3) - abs((3 * @{Misc-Skill-3-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-3-name}" name="attr_Misc-Skill-3-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3}" type="number" name="attr_Misc-Skill-3" value="(@{Misc-Skill-3-ranks} + @{Misc-Skill-3-class} + @{Misc-Skill-3-ability} + @{Misc-Skill-3-racial} + @{Misc-Skill-3-feat} + @{Misc-Skill-3-item} + @{Misc-Skill-3-acp} + @{Misc-Skill-3-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-ranks}" type="number" name="attr_Misc-Skill-3-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-class}" type="number" name="attr_Misc-Skill-3-class" value="@{Misc-Skill-3-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Misc-Skill-3-ability}" name="attr_Misc-Skill-3-ability">
+						<option value="0">None</option>
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-ability}" type="number" name="attr_Misc-Skill-3-ability-display" value="@{Misc-Skill-3-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-racial}" type="number" name="attr_Misc-Skill-3-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-feat}" type="number" name="attr_Misc-Skill-3-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-item}" type="number" name="attr_Misc-Skill-3-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-acp}" type="checkbox" name="attr_Misc-Skill-3-acp" value="@{acp}"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-misc}" type="number" name="attr_Misc-Skill-3-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-4-Check}" type="roll" value="@{character_name}'s @{Misc-Skill-4-name} check: [[1d20 + @{Misc-Skill-4}]]" name="roll_Misc-Skill-4-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-cs}" type="checkbox" name="attr_Misc-Skill-4-cs" value="((((3 * @{Misc-Skill-4-ranks}) + 3) - abs((3 * @{Misc-Skill-4-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-4-name}" name="attr_Misc-Skill-4-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4}" type="number" name="attr_Misc-Skill-4" value="(@{Misc-Skill-4-ranks} + @{Misc-Skill-4-class} + @{Misc-Skill-4-ability} + @{Misc-Skill-4-racial} + @{Misc-Skill-4-feat} + @{Misc-Skill-4-item} + @{Misc-Skill-4-acp} + @{Misc-Skill-4-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-ranks}" type="number" name="attr_Misc-Skill-4-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-class}" type="number" name="attr_Misc-Skill-4-class" value="@{Misc-Skill-4-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Misc-Skill-4-ability}" name="attr_Misc-Skill-4-ability">
+						<option value="0">None</option>
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-ability}" type="number" name="attr_Misc-Skill-4-ability-display" value="@{Misc-Skill-4-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-racial}" type="number" name="attr_Misc-Skill-4-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-feat}" type="number" name="attr_Misc-Skill-4-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-item}" type="number" name="attr_Misc-Skill-4-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-acp}" type="checkbox" name="attr_Misc-Skill-4-acp" value="@{acp}"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-misc}" type="number" name="attr_Misc-Skill-4-misc" value="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-5-Check}" type="roll" value="@{character_name}'s @{Misc-Skill-5-name} check: [[1d20 + @{Misc-Skill-5}]]" name="roll_Misc-Skill-5-Check"></button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-cs}" type="checkbox" name="attr_Misc-Skill-5-cs" value="((((3 * @{Misc-Skill-5-ranks}) + 3) - abs((3 * @{Misc-Skill-5-ranks}) - 3)) / 2)" /></span>
+				<span class="sheet-table-data sheet-center"></span>
+				<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-5-name}" name="attr_Misc-Skill-5-name"></span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5}" type="number" name="attr_Misc-Skill-5" value="(@{Misc-Skill-5-ranks} + @{Misc-Skill-5-class} + @{Misc-Skill-5-ability} + @{Misc-Skill-5-racial} + @{Misc-Skill-5-feat} + @{Misc-Skill-5-item} + @{Misc-Skill-5-acp} + @{Misc-Skill-5-misc})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-ranks}" type="number" name="attr_Misc-Skill-5-ranks" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-class}" type="number" name="attr_Misc-Skill-5-class" value="@{Misc-Skill-5-cs}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center">
+					<select title="@{Misc-Skill-5-ability}" name="attr_Misc-Skill-5-ability">
+						<option value="0">None</option>
+						<option value="@{STR-mod}">STR</option>
+						<option value="@{DEX-mod}">DEX</option>
+						<option value="@{CON-mod}">CON</option>
+						<option value="@{INT-mod}">INT</option>
+						<option value="@{WIS-mod}">WIS</option>
+						<option value="@{CHA-mod}">CHA</option>
+					</select>
+				</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-ability}" type="number" name="attr_Misc-Skill-5-ability-display" value="@{Misc-Skill-5-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-racial}" type="number" name="attr_Misc-Skill-5-racial" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-feat}" type="number" name="attr_Misc-Skill-5-feat" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-item}" type="number" name="attr_Misc-Skill-5-item" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-acp}" type="checkbox" name="attr_Misc-Skill-5-acp" value="@{acp}"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-misc}" type="number" name="attr_Misc-Skill-5-misc" value="0"></span>
+			</div>
+		</div>
+		<div class="sheet-table sheet-center sheet-sect">
+			The CS column denotes class skills. | Skills marked with * can be used Untrained
+		</div>	
+		<br>
+	</div>
+	<div>
+		<b>Skill Notes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{skill-notes-show}" name="attr_skill-notes-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-center sheet-sect">
+			<span class="sheet-table-name">Skill Notes</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-left"><textarea title="@{Skill-notes}" name="attr_Skill-notes" placeholder="Put notes about context-sensitive Skill bonuses here."></textarea></span>
+			</div>
+		</div>
+	</div>
+</div>
+<div class="sheet-section sheet-section-feats">
+ 	<div>
+		<b>Feats Available&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{feats-available-show}" name="attr_feats-available-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Feats Available</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">Feats by Level</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Racial Bonus</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Class Bonus</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Misc Bonus</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Total Feats</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><input type="number" title="@{feats-level}" name="attr_feats-level" value="(floor((@{level} + 1)/2))" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input type="number" title="@{feats-race}" name="attr_feats-race" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input type="number" title="@{feats-class}" name="attr_feats-class" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input type="number" title="@{feats-misc}" name="attr_feats-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input type="number" title="@{feats-total}" name="attr_feats-total" value="(@{feats-level} + @{feats-race} + @{feats-class} + @{feats-misc})" disabled></span>
+			</div>
+		</div>
+		<br>
+	</div>
+	<div>
+		<b>Feats&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{feats-show}" name="attr_feats-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Feat Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_0_Display" title="%{selected|repeating_feat_0_Display}" value="/em is activating their @{repeating_feat_0_name} feat&#x00A;@{repeating_feat_0_short-description}&#x00A;@{repeating_feat_0_name} uses remaining: [[@{repeating_feat_0_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_1_Display" title="%{selected|repeating_feat_1_Display}" value="/em is activating their @{repeating_feat_1_name} feat&#x00A;@{repeating_feat_1_short-description}&#x00A;@{repeating_feat_1_name} uses remaining: [[@{repeating_feat_1_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_2_Display" title="%{selected|repeating_feat_2_Display}" value="/em is activating their @{repeating_feat_2_name} feat&#x00A;@{repeating_feat_2_short-description}&#x00A;@{repeating_feat_2_name} uses remaining: [[@{repeating_feat_2_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_3_Display" title="%{selected|repeating_feat_3_Display}" value="/em is activating their @{repeating_feat_3_name} feat&#x00A;@{repeating_feat_3_short-description}&#x00A;@{repeating_feat_3_name} uses remaining: [[@{repeating_feat_3_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_4_Display" title="%{selected|repeating_feat_4_Display}" value="/em is activating their @{repeating_feat_4_name} feat&#x00A;@{repeating_feat_4_short-description}&#x00A;@{repeating_feat_4_name} uses remaining: [[@{repeating_feat_4_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_5_Display" title="%{selected|repeating_feat_5_Display}" value="/em is activating their @{repeating_feat_5_name} feat&#x00A;@{repeating_feat_5_short-description}&#x00A;@{repeating_feat_5_name} uses remaining: [[@{repeating_feat_5_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_6_Display" title="%{selected|repeating_feat_6_Display}" value="/em is activating their @{repeating_feat_6_name} feat&#x00A;@{repeating_feat_6_short-description}&#x00A;@{repeating_feat_6_name} uses remaining: [[@{repeating_feat_6_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_7_Display" title="%{selected|repeating_feat_7_Display}" value="/em is activating their @{repeating_feat_7_name} feat&#x00A;@{repeating_feat_7_short-description}&#x00A;@{repeating_feat_7_name} uses remaining: [[@{repeating_feat_7_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_8_Display" title="%{selected|repeating_feat_8_Display}" value="/em is activating their @{repeating_feat_8_name} feat&#x00A;@{repeating_feat_8_short-description}&#x00A;@{repeating_feat_8_name} uses remaining: [[@{repeating_feat_8_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_9_Display" title="%{selected|repeating_feat_9_Display}" value="/em is activating their @{repeating_feat_9_name} feat&#x00A;@{repeating_feat_9_short-description}&#x00A;@{repeating_feat_9_name} uses remaining: [[@{repeating_feat_9_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_10_Display" title="%{selected|repeating_feat_10_Display}" value="/em is activating their @{repeating_feat_10_name} feat&#x00A;@{repeating_feat_10_short-description}&#x00A;@{repeating_feat_10_name} uses remaining: [[@{repeating_feat_10_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_11_Display" title="%{selected|repeating_feat_11_Display}" value="/em is activating their @{repeating_feat_11_name} feat&#x00A;@{repeating_feat_11_short-description}&#x00A;@{repeating_feat_11_name} uses remaining: [[@{repeating_feat_11_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_12_Display" title="%{selected|repeating_feat_12_Display}" value="/em is activating their @{repeating_feat_12_name} feat&#x00A;@{repeating_feat_12_short-description}&#x00A;@{repeating_feat_12_name} uses remaining: [[@{repeating_feat_12_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_13_Display" title="%{selected|repeating_feat_13_Display}" value="/em is activating their @{repeating_feat_13_name} feat&#x00A;@{repeating_feat_13_short-description}&#x00A;@{repeating_feat_13_name} uses remaining: [[@{repeating_feat_13_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_14_Display" title="%{selected|repeating_feat_14_Display}" value="/em is activating their @{repeating_feat_14_name} feat&#x00A;@{repeating_feat_14_short-description}&#x00A;@{repeating_feat_14_name} uses remaining: [[@{repeating_feat_14_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_15_Display" title="%{selected|repeating_feat_15_Display}" value="/em is activating their @{repeating_feat_15_name} feat&#x00A;@{repeating_feat_15_short-description}&#x00A;@{repeating_feat_15_name} uses remaining: [[@{repeating_feat_15_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_16_Display" title="%{selected|repeating_feat_16_Display}" value="/em is activating their @{repeating_feat_16_name} feat&#x00A;@{repeating_feat_16_short-description}&#x00A;@{repeating_feat_16_name} uses remaining: [[@{repeating_feat_16_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_17_Display" title="%{selected|repeating_feat_17_Display}" value="/em is activating their @{repeating_feat_17_name} feat&#x00A;@{repeating_feat_17_short-description}&#x00A;@{repeating_feat_17_name} uses remaining: [[@{repeating_feat_17_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_18_Display" title="%{selected|repeating_feat_18_Display}" value="/em is activating their @{repeating_feat_18_name} feat&#x00A;@{repeating_feat_18_short-description}&#x00A;@{repeating_feat_18_name} uses remaining: [[@{repeating_feat_18_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_19_Display" title="%{selected|repeating_feat_19_Display}" value="/em is activating their @{repeating_feat_19_name} feat&#x00A;@{repeating_feat_19_short-description}&#x00A;@{repeating_feat_19_name} uses remaining: [[@{repeating_feat_19_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_20_Display" title="%{selected|repeating_feat_20_Display}" value="/em is activating their @{repeating_feat_20_name} feat&#x00A;@{repeating_feat_20_short-description}&#x00A;@{repeating_feat_20_name} uses remaining: [[@{repeating_feat_20_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_21_Display" title="%{selected|repeating_feat_21_Display}" value="/em is activating their @{repeating_feat_21_name} feat&#x00A;@{repeating_feat_21_short-description}&#x00A;@{repeating_feat_21_name} uses remaining: [[@{repeating_feat_21_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_22_Display" title="%{selected|repeating_feat_22_Display}" value="/em is activating their @{repeating_feat_22_name} feat&#x00A;@{repeating_feat_22_short-description}&#x00A;@{repeating_feat_22_name} uses remaining: [[@{repeating_feat_22_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_23_Display" title="%{selected|repeating_feat_23_Display}" value="/em is activating their @{repeating_feat_23_name} feat&#x00A;@{repeating_feat_23_short-description}&#x00A;@{repeating_feat_23_name} uses remaining: [[@{repeating_feat_23_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_24_Display" title="%{selected|repeating_feat_24_Display}" value="/em is activating their @{repeating_feat_24_name} feat&#x00A;@{repeating_feat_24_short-description}&#x00A;@{repeating_feat_24_name} uses remaining: [[@{repeating_feat_24_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_25_Display" title="%{selected|repeating_feat_25_Display}" value="/em is activating their @{repeating_feat_25_name} feat&#x00A;@{repeating_feat_25_short-description}&#x00A;@{repeating_feat_25_name} uses remaining: [[@{repeating_feat_25_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_feat_26_Display" title="%{selected|repeating_feat_26_Display}" value="/em is activating their @{repeating_feat_26_name} feat&#x00A;@{repeating_feat_26_short-description}&#x00A;@{repeating_feat_26_name} uses remaining: [[@{repeating_feat_26_used}-1]]"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Feats</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header" style="width:5%;"></span>
+				<span class="sheet-table-header" style="width:23%;">Name</span>
+				<span class="sheet-table-header" style="width:45%;">Short Description</span>
+				<span class="sheet-table-header" style="width:5%;">Used</span>
+				<span class="sheet-table-header" style="width:2%;vertical-align:bottom;font-size:150%;">/</span>
+				<span class="sheet-table-header" style="width:5%;">Max</span>
+				<span class="sheet-table-header" style="width:15%;">Max Calculation</span>
+			</div>
+		</div>
+		<div class="sheet-table sheet-sect">
+			<fieldset class="repeating_feat">  
+				<span class="sheet-table-data sheet-center" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+				<span class="sheet-table-data sheet-center" style="width:23%;"><input title="@{repeating_feat_X_name}" type="text" name="attr_name" placeholder="Feat Name"></span>
+				<span class="sheet-table-data sheet-center" style="width:45%;"><input title="@{repeating_feat_X_short-description}" type="text" name="attr_short-description" placeholder="Short Description"></span>
+				<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_feat_X_used}" type="number" name="attr_used" value="0"></span>
+				<span class="sheet-table-data sheet-center" style="width:2%;vertical-align:middle;font-size:150%;">/</span>
+				<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_feat_X_used|max" type="number" name="attr_used_max" value="@{max-calculation}" disabled></span>
+				<span class="sheet-table-data sheet-center" style="width:15%;"><input title="@{repeating_feat_X_max-calculation}" type="text" name="attr_max-calculation" value="0"></span>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_feat_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_feat_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_feat_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_feat_X_macro-text}" name="attr_macro-text">/em is activating their @{name} feat&#x00A;@{short-description}&#x00A;@{name} uses remaining: [[@{used}-1]]</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+</div>
+<div class="sheet-section sheet-section-inventory">
+	<div>
+		<b>Currency&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{currency-show}" name="attr_currency-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Currency</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name">CP</span>
+				<span class="sheet-table-data sheet-center"><input title="@{CP}" type="number" name="attr_CP" value="0" style="width:100%;"></span>
+				<span class="sheet-table-row-name">SP</span>
+				<span class="sheet-table-data sheet-center"><input title="@{SP}" type="number" name="attr_SP" value="0" style="width:100%;"></span>
+				<span class="sheet-table-row-name">GP</span>
+				<span class="sheet-table-data sheet-center"><input title="@{GP}" type="number" name="attr_GP" value="0" style="width:100%;"></span>
+				<span class="sheet-table-row-name">PP</span>
+				<span class="sheet-table-data sheet-center"><input title="@{PP}" type="number" name="attr_PP" value="0" style="width:100%;"></span>
+			</div>
+		</div>
+		<br>
+	</div>
+	<div>
+		<b>Worn Magic Equipment&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{worn-equipment-show}" name="attr_worn-equipment-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Worn Magic Equipment</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header" style="width:10%;">Slot</span>
+				<span class="sheet-table-header">Name</span>
+				<span class="sheet-table-header">Description</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Belt:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Belt}" type="text" name="attr_worn-Belt" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Belt-description}" type="text" name="attr_worn-Belt-description" placeholder="Description"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Body:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Body}" type="text" name="attr_worn-Body" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Body-description}" type="text" name="attr_worn-Body-description" placeholder="Description"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Chest:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Chest}" type="text" name="attr_worn-Chest" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Chest-description}" type="text" name="attr_worn-Chest-description" placeholder="Description"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Eyes:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Eyes}" type="text" name="attr_worn-Eyes" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Eyes-description}" type="text" name="attr_worn-Eyes-description" placeholder="Description"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Feet:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Feet}" type="text" name="attr_worn-Feet" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Feet-description}" type="text" name="attr_worn-Feet-description" placeholder="Description"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Hands:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Hands}" type="text" name="attr_worn-Hands" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Hands-description}" type="text" name="attr_worn-Hands-description" placeholder="Description"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Head:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Head}" type="text" name="attr_worn-Head" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Head-description}" type="text" name="attr_worn-Head-description" placeholder="Description"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Headband:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Headband}" type="text" name="attr_worn-Headband" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Headband-description}" type="text" name="attr_worn-Headband-description" placeholder="Description"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Neck:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Neck}" type="text" name="attr_worn-Neck" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Neck-description}" type="text" name="attr_worn-Neck-description" placeholder="Description"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Ring 1:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Ring1}" type="text" name="attr_worn-Ring1" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Ring1-description}" type="text" name="attr_worn-Ring1-description" placeholder="Description"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Ring 2:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Ring2}" type="text" name="attr_worn-Ring2" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Ring2-description}" type="text" name="attr_worn-Ring2-description" placeholder="Description"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Shoulders:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Shoulders}" type="text" name="attr_worn-Shoulders" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Shoulders-description}" type="text" name="attr_worn-Shoulders-description" placeholder="Description"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-right" style="width:10%;">Wrist:</span>
+				<span class="sheet-table-data sheet-left" style="width:30%;"><input title="@{worn-Wrist}" type="text" name="attr_worn-Wrist" placeholder="Name"></span>
+				<span class="sheet-table-data sheet-left" style="width:60%;"><input title="@{worn-Wrist-description}" type="text" name="attr_worn-Wrist-description" placeholder="Description"></span>
+			</div>
+		</div>		
+		<br>
+	</div>
+	<div>
+		<b>Inventory&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{inventory-show}" name="attr_inventory-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Inventory Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_0_Display" title="%{selected|repeating_item_0_Display}" value="/em is using their item, @{repeating_item_0_name}&#x00A;@{repeating_item_0_short-description}&#x00A;@{repeating_item_0_name} uses remaining: [[@{repeating_item_0_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_1_Display" title="%{selected|repeating_item_1_Display}" value="/em is using their item, @{repeating_item_1_name}&#x00A;@{repeating_item_1_short-description}&#x00A;@{repeating_item_1_name} uses remaining: [[@{repeating_item_1_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_2_Display" title="%{selected|repeating_item_2_Display}" value="/em is using their item, @{repeating_item_2_name}&#x00A;@{repeating_item_2_short-description}&#x00A;@{repeating_item_2_name} uses remaining: [[@{repeating_item_2_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_3_Display" title="%{selected|repeating_item_3_Display}" value="/em is using their item, @{repeating_item_3_name}&#x00A;@{repeating_item_3_short-description}&#x00A;@{repeating_item_3_name} uses remaining: [[@{repeating_item_3_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_4_Display" title="%{selected|repeating_item_4_Display}" value="/em is using their item, @{repeating_item_4_name}&#x00A;@{repeating_item_4_short-description}&#x00A;@{repeating_item_4_name} uses remaining: [[@{repeating_item_4_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_5_Display" title="%{selected|repeating_item_5_Display}" value="/em is using their item, @{repeating_item_5_name}&#x00A;@{repeating_item_5_short-description}&#x00A;@{repeating_item_5_name} uses remaining: [[@{repeating_item_5_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_6_Display" title="%{selected|repeating_item_6_Display}" value="/em is using their item, @{repeating_item_6_name}&#x00A;@{repeating_item_6_short-description}&#x00A;@{repeating_item_6_name} uses remaining: [[@{repeating_item_6_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_7_Display" title="%{selected|repeating_item_7_Display}" value="/em is using their item, @{repeating_item_7_name}&#x00A;@{repeating_item_7_short-description}&#x00A;@{repeating_item_7_name} uses remaining: [[@{repeating_item_7_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_8_Display" title="%{selected|repeating_item_8_Display}" value="/em is using their item, @{repeating_item_8_name}&#x00A;@{repeating_item_8_short-description}&#x00A;@{repeating_item_8_name} uses remaining: [[@{repeating_item_8_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_9_Display" title="%{selected|repeating_item_9_Display}" value="/em is using their item, @{repeating_item_9_name}&#x00A;@{repeating_item_9_short-description}&#x00A;@{repeating_item_9_name} uses remaining: [[@{repeating_item_9_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_10_Display" title="%{selected|repeating_item_10_Display}" value="/em is using their item, @{repeating_item_10_name}&#x00A;@{repeating_item_10_short-description}&#x00A;@{repeating_item_10_name} uses remaining: [[@{repeating_item_10_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_11_Display" title="%{selected|repeating_item_11_Display}" value="/em is using their item, @{repeating_item_11_name}&#x00A;@{repeating_item_11_short-description}&#x00A;@{repeating_item_11_name} uses remaining: [[@{repeating_item_11_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_12_Display" title="%{selected|repeating_item_12_Display}" value="/em is using their item, @{repeating_item_12_name}&#x00A;@{repeating_item_12_short-description}&#x00A;@{repeating_item_12_name} uses remaining: [[@{repeating_item_12_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_13_Display" title="%{selected|repeating_item_13_Display}" value="/em is using their item, @{repeating_item_13_name}&#x00A;@{repeating_item_13_short-description}&#x00A;@{repeating_item_13_name} uses remaining: [[@{repeating_item_13_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_14_Display" title="%{selected|repeating_item_14_Display}" value="/em is using their item, @{repeating_item_14_name}&#x00A;@{repeating_item_14_short-description}&#x00A;@{repeating_item_14_name} uses remaining: [[@{repeating_item_14_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_15_Display" title="%{selected|repeating_item_15_Display}" value="/em is using their item, @{repeating_item_15_name}&#x00A;@{repeating_item_15_short-description}&#x00A;@{repeating_item_15_name} uses remaining: [[@{repeating_item_15_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_16_Display" title="%{selected|repeating_item_16_Display}" value="/em is using their item, @{repeating_item_16_name}&#x00A;@{repeating_item_16_short-description}&#x00A;@{repeating_item_16_name} uses remaining: [[@{repeating_item_16_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_17_Display" title="%{selected|repeating_item_17_Display}" value="/em is using their item, @{repeating_item_17_name}&#x00A;@{repeating_item_17_short-description}&#x00A;@{repeating_item_17_name} uses remaining: [[@{repeating_item_17_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_18_Display" title="%{selected|repeating_item_18_Display}" value="/em is using their item, @{repeating_item_18_name}&#x00A;@{repeating_item_18_short-description}&#x00A;@{repeating_item_18_name} uses remaining: [[@{repeating_item_18_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_19_Display" title="%{selected|repeating_item_19_Display}" value="/em is using their item, @{repeating_item_19_name}&#x00A;@{repeating_item_19_short-description}&#x00A;@{repeating_item_19_name} uses remaining: [[@{repeating_item_19_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_20_Display" title="%{selected|repeating_item_20_Display}" value="/em is using their item, @{repeating_item_20_name}&#x00A;@{repeating_item_20_short-description}&#x00A;@{repeating_item_20_name} uses remaining: [[@{repeating_item_20_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_21_Display" title="%{selected|repeating_item_21_Display}" value="/em is using their item, @{repeating_item_21_name}&#x00A;@{repeating_item_21_short-description}&#x00A;@{repeating_item_21_name} uses remaining: [[@{repeating_item_21_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_22_Display" title="%{selected|repeating_item_22_Display}" value="/em is using their item, @{repeating_item_22_name}&#x00A;@{repeating_item_22_short-description}&#x00A;@{repeating_item_22_name} uses remaining: [[@{repeating_item_22_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_23_Display" title="%{selected|repeating_item_23_Display}" value="/em is using their item, @{repeating_item_23_name}&#x00A;@{repeating_item_23_short-description}&#x00A;@{repeating_item_23_name} uses remaining: [[@{repeating_item_23_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_24_Display" title="%{selected|repeating_item_24_Display}" value="/em is using their item, @{repeating_item_24_name}&#x00A;@{repeating_item_24_short-description}&#x00A;@{repeating_item_24_name} uses remaining: [[@{repeating_item_24_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_25_Display" title="%{selected|repeating_item_25_Display}" value="/em is using their item, @{repeating_item_25_name}&#x00A;@{repeating_item_25_short-description}&#x00A;@{repeating_item_25_name} uses remaining: [[@{repeating_item_25_qty}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_item_26_Display" title="%{selected|repeating_item_26_Display}" value="/em is using their item, @{repeating_item_26_name}&#x00A;@{repeating_item_26_short-description}&#x00A;@{repeating_item_26_name} uses remaining: [[@{repeating_item_26_qty}-1]]"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Inventory</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header" style="width:5%;"></span>
+				<span class="sheet-table-header" style="width:23%;">Name</span>
+				<span class="sheet-table-header" style="width:55%;">Short Description</span>
+				<span class="sheet-table-header" style="width:5%;">Charges/Qty</span>
+				<span class="sheet-table-header" style="width:2%;vertical-align:bottom;font-size:150%;">/</span>
+				<span class="sheet-table-header" style="width:5%;">Max</span>
+				<span class="sheet-table-header" style="width:5%;">Weight</span>
+			</div>
+		</div>
+		<div class="sheet-table sheet-sect">
+			<fieldset class="repeating_item">  
+				<span class="sheet-table-data sheet-center" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+				<span class="sheet-table-data sheet-center" style="width:23%;"><input title="@{repeating_item_X_name}" type="text" name="attr_name" placeholder="Item Name"></span>
+				<span class="sheet-table-data sheet-center" style="width:55%;"><input title="@{repeating_item_X_short-description}" type="text" name="attr_short-description" placeholder="Short Description"></span>
+				<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_item_X_qty}" type="number" name="attr_qty" value="0"></span>
+				<span class="sheet-table-data sheet-center" style="width:2%;vertical-align:middle;font-size:150%;">/</span>
+				<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_item_X_qty|max" type="number" name="attr_qty_max" value="0"></span>
+				<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_item_X_weight}" type="number" name="attr_weight" value="0" step="any" min="0"></span>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_item_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_item_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_item_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_item_X_macro-text}" name="attr_macro-text">/em is using their item @{name}&#x00A;@{short-description}&#x00A;@{name} uses remaining: [[@{qty}-1]]</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+	<div>
+		<b>Carried Weight&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{carried-weight-show}" name="attr_carried-weight-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Carried Weight</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">Armor & Weapons</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Currency</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Equipment</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Misc</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Total</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{carried-armor-and-weapons}" type="number" name="attr_carried-armor-and-weapons" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{carried-currency}" type="number" name="attr_carried-currency" value="((@{CP} + @{SP} + @{GP} + @{PP})/50)" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{carried-equipment}" type="number" name="attr_carried-equipment" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{carried-misc}" type="number" name="attr_carried-misc" value="0" min="0"></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{carried-total}" type="number" name="attr_carried-total" value="(@{carried-armor-and-weapons} + @{carried-currency} + @{carried-equipment} + @{carried-misc})" disabled></span>
+			</div>
+		</div>
+		<br>
+	</div>
+	<div>
+		<b>Loads and Lift&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{loads-show}" name="attr_loads-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Loads and Lift</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">Light</span>
+				<span class="sheet-table-header">Medium</span>
+				<span class="sheet-table-header">Heavy</span>
+				<span class="sheet-table-header" style="background-color:black;"></span>
+				<span class="sheet-table-header">Above Head</span>
+				<span class="sheet-table-header">Off Ground</span>
+				<span class="sheet-table-header">Drag & Push</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{load-light}" type="number" name="attr_load-light" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{load-medium}" type="number" name="attr_load-medium" value="0"></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{load-heavy}" type="number" name="attr_load-heavy" value="0"></span>
+				<span class="sheet-table-data sheet-center" style="background-color:black;">&nbsp;</span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{lift-above-head}" type="number" name="attr_lift-above-head" value="@{load-heavy}" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{lift-off-ground}" type="number" name="attr_lift-off-ground" value="(@{load-heavy} * 2)" disabled></span>
+				<span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{lift-drag-and-push}" type="number" name="attr_lift-drag-and-push" value="(@{load-heavy} * 5)" disabled></span>
+			</div>
+		</div>
+		<div class="sheet-table sheet-sect">
+			<div class="sheet-table-row">
+				<div class="sheet-table-row">
+					<span class="sheet-table-row-name" style="width:10%;">Current Load</span>
+					<span class="sheet-table-data sheet-center" style="width:10%;"><input title="@{current-load}" type="radio" value="0" name="attr_current-load" checked> Light</span>
+					<span class="sheet-table-data sheet-center" style="width:10%;"><input title="@{current-load}" type="radio" value="1" name="attr_current-load"> Medium</span>
+					<span class="sheet-table-data sheet-center" style="width:10%;"><input title="@{current-load}" type="radio" value="2" name="attr_current-load"> Heavy</span>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+<div class="sheet-section sheet-section-spells">
+	<div>
+		<b>Spells per Day&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{spd-show}" name="attr_spd-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<div class="sheet-table-row">
+				<div class="sheet-table-data sheet-center">
+					<div class="sheet-table">
+						<span class="sheet-table-name">Spells Per Day</span>
+						<div class="sheet-table-row">
+							<span class="sheet-table-header">Class</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">Total</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">CL</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">Misc</span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-left"><input title="@{spellclass-0-name}" type="text" name="attr_spellclass-0-name" placeholder="Class Name"></span>
+							<span class="sheet-table-data sheet-left"><button style="font-size:100%;" title="%{selected|Spell-Class-0-CL-Check}" type="roll" name="roll_Spell-Class-0-CL-Check" value="&{template:pf_check} {{name=Caster Level Check}} {{caster_class=@{spellclass-0-name} [[@{spellclass-0-level}]] }} {{caster_lvl_chk=[[1d20 + @{spellclass-0-level} + @{spellclass-0-level-misc}]] }}">CL Check</button></span>
+							<span class="sheet-table-data sheet-left"><input title="@{spellclass-0-level-total}" type="number" name="attr_spellclass-0-level-total" value="(@{spellclass-0-level} + @{spellclass-0-level-misc})" disabled></span>
+							<span class="sheet-table-data sheet-left">=</span>
+							<span class="sheet-table-data sheet-left"><input title="@{spellclass-0-level}" type="number" name="attr_spellclass-0-level" value="0"></span>
+							<span class="sheet-table-data sheet-left">+</span>
+							<span class="sheet-table-data sheet-left"><input title="@{spellclass-0-level-misc}" type="number" name="attr_spellclass-0-level-misc" value="0"></span>
+						</div>
+					</div>
+					<div class="sheet-table">
+						<div class="sheet-table-row">
+							<span class="sheet-table-header">Concentration Check</span>
+							<span class="sheet-table-header">Total</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">Ability</span>
+							<span class="sheet-table-header">Mod</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">Misc</span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Concentration-Check-0}" type="roll" value="&{template:pf_check} {{name=Concentration Check}} {{caster_class=@{spellclass-0-name} [[@{spellclass-0-level}]] }} {{concentration_chk=[[1d20 + @{Concentration-0}]] }}">Concentration</button></span>
+							<span class="sheet-table-data sheet-center"><input title="@{Concentration-0}" type="number" name="attr_Concentration-0" value="(@{spellclass-0-level} + @{Concentration-0-ability} + @{Concentration-0-misc})" disabled></span>
+							<span class="sheet-table-data sheet-center">=</span>
+							<span class="sheet-table-data sheet-center">
+								<select title="@{Concentration-0-ability}" name="attr_Concentration-0-ability">
+									<option value="0" selected>None</option>
+									<option value="(@{STR-mod})">STR</option>
+									<option value="(@{DEX-mod})">DEX</option>
+									<option value="(@{CON-mod})">CON</option>
+									<option value="(@{INT-mod})">INT</option>
+									<option value="(@{WIS-mod})">WIS</option>
+									<option value="(@{CHA-mod})">CHA</option>
+								</select>
+						  </span>
+							<span class="sheet-table-data sheet-center"><input title="@{Concentration-0-mod}" type="number" name="attr_Concentration-0-mod" value="@{Concentration-0-ability}" disabled></span>
+							<span class="sheet-table-data sheet-center">+</span>
+							<span class="sheet-table-data sheet-center"><input title="@{Concentration-0-misc}" type="number" name="attr_Concentration-0-misc" value="0"></span>
+						</div>
+					</div>
+					<div class="sheet-table">
+						<div class="sheet-table-row">
+							<span class="sheet-table-header">Save DC</span>
+							<span class="sheet-table-header">Level</span>
+							<span class="sheet-table-header">Uses</span>
+							<span class="sheet-table-header">Total</span>
+							<span class="sheet-table-header">Spells / Day</span>
+							<span class="sheet-table-header">Bonus Spells</span>
+							<span class="sheet-table-header">Misc</span>
+							<span class="sheet-table-header">Spells Known</span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-0-savedc}" type="number" name="attr_spellclass-0-level-0-savedc" value="(10 + 0 + @{Concentration-0-ability})" disabled></span>
+							<span class="sheet-table-header">0</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-0-spells-per-day}" type="number" name="attr_spellclass-0-level-0-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-0-spells-per-day|max" type="number" name="attr_spellclass-0-level-0-spells-per-day_max" value="(@{spellclass-0-level-0-class} + @{spellclass-0-level-0-misc})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-0-class}" type="number" name="attr_spellclass-0-level-0-class"></span>
+							<span class="sheet-table-data sheet-center">
+								<select title="@{Concentration-0-ability}" name="attr_Concentration-0-ability">
+									<option value="0" selected>None</option>
+									<option value="(@{STR-mod})">STR</option>
+									<option value="(@{DEX-mod})">DEX</option>
+									<option value="(@{CON-mod})">CON</option>
+									<option value="(@{INT-mod})">INT</option>
+									<option value="(@{WIS-mod})">WIS</option>
+									<option value="(@{CHA-mod})">CHA</option>
+								</select>
+							</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-0-misc}" type="number" name="attr_spellclass-0-level-0-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-0-spells-known}" type="number" name="attr_spellclass-0-level-0-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-1-savedc}" type="number" name="attr_spellclass-0-level-1-savedc" value="(10 + 1 + @{Concentration-0-ability})" disabled></span>
+							<span class="sheet-table-header">1st</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-1-spells-per-day}" type="number" name="attr_spellclass-0-level-1-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-1-spells-per-day|max" type="number" name="attr_spellclass-0-level-1-spells-per-day_max" value="(@{spellclass-0-level-1-misc} + @{spellclass-0-level-1-class} + @{spellclass-0-level-1-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-1-class}" type="number" name="attr_spellclass-0-level-1-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-1-bonus}" type="number" name="attr_spellclass-0-level-1-bonus" value="((((ceil(@{Concentration-0-ability}/4) + 0) + abs(ceil(@{Concentration-0-ability}/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-1-misc}" type="number" name="attr_spellclass-0-level-1-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-1-spells-known}" type="number" name="attr_spellclass-0-level-1-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-2-savedc}" type="number" name="attr_spellclass-0-level-2-savedc" value="(10 + 2 + @{Concentration-0-ability})" disabled></span>
+							<span class="sheet-table-header">2nd</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-2-spells-per-day}" type="number" name="attr_spellclass-0-level-2-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-2-spells-per-day|max" type="number" name="attr_spellclass-0-level-2-spells-per-day_max" value="(@{spellclass-0-level-2-misc} + @{spellclass-0-level-2-class} + @{spellclass-0-level-2-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-2-class}" type="number" name="attr_spellclass-0-level-2-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-2-bonus}" type="number" name="attr_spellclass-0-level-2-bonus" value="((((ceil((@{Concentration-0-ability} - 1)/4) + 0) + abs(ceil((@{Concentration-0-ability} - 1)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-2-misc}" type="number" name="attr_spellclass-0-level-2-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-2-spells-known}" type="number" name="attr_spellclass-0-level-2-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-3-savedc}" type="number" name="attr_spellclass-0-level-3-savedc" value="(10 + 3 + @{Concentration-0-ability})" disabled></span>
+							<span class="sheet-table-header">3rd</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-3-spells-per-day}" type="number" name="attr_spellclass-0-level-3-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-3-spells-per-day|max" type="number" name="attr_spellclass-0-level-3-spells-per-day_max" value="(@{spellclass-0-level-3-misc} + @{spellclass-0-level-3-class} + @{spellclass-0-level-3-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-3-class}" type="number" name="attr_spellclass-0-level-3-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-3-bonus}" type="number" name="attr_spellclass-0-level-3-bonus" value="((((ceil((@{Concentration-0-ability} - 2)/4) + 0) + abs(ceil((@{Concentration-0-ability} - 2)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-3-misc}" type="number" name="attr_spellclass-0-level-3-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-3-spells-known}" type="number" name="attr_spellclass-0-level-3-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-4-savedc}" type="number" name="attr_spellclass-0-level-4-savedc" value="(10 + 4 + @{Concentration-0-ability})" disabled></span>
+							<span class="sheet-table-header">4th</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-4-spells-per-day}" type="number" name="attr_spellclass-0-level-4-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-4-spells-per-day|max" type="number" name="attr_spellclass-0-level-4-spells-per-day_max" value="(@{spellclass-0-level-4-misc} + @{spellclass-0-level-4-class} + @{spellclass-0-level-4-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-4-class}" type="number" name="attr_spellclass-0-level-4-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-4-bonus}" type="number" name="attr_spellclass-0-level-4-bonus" value="((((ceil((@{Concentration-0-ability} - 3)/4) + 0) + abs(ceil((@{Concentration-0-ability} - 3)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-4-misc}" type="number" name="attr_spellclass-0-level-4-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-4-spells-known}" type="number" name="attr_spellclass-0-level-4-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-5-savedc}" type="number" name="attr_spellclass-0-level-5-savedc" value="(10 + 5 + @{Concentration-0-ability})" disabled></span>
+							<span class="sheet-table-header">5th</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-5-spells-per-day}" type="number" name="attr_spellclass-0-level-5-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-5-spells-per-day|max" type="number" name="attr_spellclass-0-level-5-spells-per-day_max" value="(@{spellclass-0-level-5-misc} + @{spellclass-0-level-5-class} + @{spellclass-0-level-5-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-5-class}" type="number" name="attr_spellclass-0-level-5-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-5-bonus}" type="number" name="attr_spellclass-0-level-5-bonus" value="((((ceil((@{Concentration-0-ability} - 4)/4) + 0) + abs(ceil((@{Concentration-0-ability} - 4)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-5-misc}" type="number" name="attr_spellclass-0-level-5-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-5-spells-known}" type="number" name="attr_spellclass-0-level-5-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-6-savedc}" type="number" name="attr_spellclass-0-level-6-savedc" value="(10 + 6 + @{Concentration-0-ability})" disabled></span>
+							<span class="sheet-table-header">6th</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-6-spells-per-day}" type="number" name="attr_spellclass-0-level-6-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-6-spells-per-day|max" type="number" name="attr_spellclass-0-level-6-spells-per-day_max" value="(@{spellclass-0-level-6-misc} + @{spellclass-0-level-6-class} + @{spellclass-0-level-6-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-6-class}" type="number" name="attr_spellclass-0-level-6-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-6-bonus}" type="number" name="attr_spellclass-0-level-6-bonus" value="((((ceil((@{Concentration-0-ability} - 5)/4) + 0) + abs(ceil((@{Concentration-0-ability} - 5)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-6-misc}" type="number" name="attr_spellclass-0-level-6-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-6-spells-known}" type="number" name="attr_spellclass-0-level-6-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-7-savedc}" type="number" name="attr_spellclass-0-level-7-savedc" value="(10 + 7 + @{Concentration-0-ability})" disabled></span>
+							<span class="sheet-table-header">7th</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-7-spells-per-day}" type="number" name="attr_spellclass-0-level-7-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-7-spells-per-day|max" type="number" name="attr_spellclass-0-level-7-spells-per-day_max" value="(@{spellclass-0-level-7-misc} + @{spellclass-0-level-7-class} + @{spellclass-0-level-7-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-7-class}" type="number" name="attr_spellclass-0-level-7-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-7-bonus}" type="number" name="attr_spellclass-0-level-7-bonus" value="((((ceil((@{Concentration-0-ability} - 6)/4) + 0) + abs(ceil((@{Concentration-0-ability} - 6)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-7-misc}" type="number" name="attr_spellclass-0-level-7-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-7-spells-known}" type="number" name="attr_spellclass-0-level-7-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-8-savedc}" type="number" name="attr_spellclass-0-level-8-savedc" value="(10 + 8 + @{Concentration-0-ability})" disabled></span>
+							<span class="sheet-table-header">8th</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-8-spells-per-day}" type="number" name="attr_spellclass-0-level-8-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-8-spells-per-day|max" type="number" name="attr_spellclass-0-level-8-spells-per-day_max" value="(@{spellclass-0-level-8-misc} + @{spellclass-0-level-8-class} + @{spellclass-0-level-8-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-8-class}" type="number" name="attr_spellclass-0-level-8-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-8-bonus}" type="number" name="attr_spellclass-0-level-8-bonus" value="((((ceil((@{Concentration-0-ability} - 7)/4) + 0) + abs(ceil((@{Concentration-0-ability} - 7)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-8-misc}" type="number" name="attr_spellclass-0-level-8-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-8-spells-known}" type="number" name="attr_spellclass-0-level-8-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-9-savedc}" type="number" name="attr_spellclass-0-level-9-savedc" value="(10 + 9 + @{Concentration-0-ability})" disabled></span>
+							<span class="sheet-table-header">9th</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-9-spells-per-day}" type="number" name="attr_spellclass-0-level-9-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-9-spells-per-day|max" type="number" name="attr_spellclass-0-level-9-spells-per-day_max" value="(@{spellclass-0-level-9-misc} + @{spellclass-0-level-9-class} + @{spellclass-0-level-9-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-9-class}" type="number" name="attr_spellclass-0-level-9-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-9-bonus}" type="number" name="attr_spellclass-0-level-9-bonus" value="((((ceil((@{Concentration-0-ability} - 8)/4) + 0) + abs(ceil((@{Concentration-0-ability} - 8)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-9-misc}" type="number" name="attr_spellclass-0-level-9-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-9-spells-known}" type="number" name="attr_spellclass-0-level-9-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"></span>
+							<span class="sheet-table-header">SP</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-spell-points-per-day}" type="number" name="attr_spellclass-0-spell-points-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-spell-points-per-day|max" type="number" name="attr_spellclass-0-spell-points-per-day_max" value="(@{spellclass-0-spell-points-class} + @{spellclass-0-spell-points-bonus} + @{spellclass-0-spell-points-misc})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-spell-points-class}" type="number" name="attr_spellclass-0-spell-points-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-spell-points-bonus}" type="number" name="attr_spellclass-0-spell-points-bonus" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-spell-points-misc}" type="number" name="attr_spellclass-0-spell-points-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"></span>
+						</div>
+					</div> 
+					<div class="sheet-table">					
+						<div class="sheet-table-row">
+							<span class="sheet-table-row-name">Close</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-close}" type="number" name="attr_spellclass-0-close" value="(25 + (5 * floor(@{spellclass-0-level} / 2)))" disabled></span>
+							<span class="sheet-table-row-name">Medium</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-medium}" type="number" name="attr_spellclass-0-medium" value="(100 + (10 * @{spellclass-0-level}))" disabled></span>
+							<span class="sheet-table-row-name">Long</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-0-long}" type="number" name="attr_spellclass-0-long" value="(400 + (40 * @{spellclass-0-level}))" disabled></span>
+						</div>
+					</div>
+				</div>
+				<div class="sheet-table-data sheet-center" style="background-color:black;">
+					&nbsp;
+				</div>
+				<div class="sheet-table-data sheet-center">
+					<div class="sheet-table">
+						<span class="sheet-table-name">Spells Per Day</span>
+						<div class="sheet-table-row">
+							<span class="sheet-table-header">Class</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">Total</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">CL</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">Misc</span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-left"><input title="@{spellclass-1-name}" type="text" name="attr_spellclass-1-name" placeholder="Class Name"></span>
+							<span class="sheet-table-data sheet-left"><button style="font-size:100%;" title="%{selected|Spell-Class-1-CL-Check}" type="roll" name="roll_Spell-Class-1-CL-Check" value="&{template:pf_check} {{name=Caster Level Check}} {{caster_class=@{spellclass-1-name} [[@{spellclass-1-level}]] }} {{caster_lvl_chk=[[1d20 + @{spellclass-1-level} + @{spellclass-1-level-misc}]] }}">CL Check</button></span>
+							<span class="sheet-table-data sheet-left"><input title="@{spellclass-1-level-total}" type="number" name="attr_spellclass-1-level-total" value="(@{spellclass-1-level} + @{spellclass-1-level-misc})" disabled></span>
+							<span class="sheet-table-data sheet-left">=</span>
+							<span class="sheet-table-data sheet-left"><input title="@{spellclass-1-level}" type="number" name="attr_spellclass-1-level" value="0"></span>
+							<span class="sheet-table-data sheet-left">+</span>
+							<span class="sheet-table-data sheet-left"><input title="@{spellclass-1-level-misc}" type="number" name="attr_spellclass-1-level-misc" value="0"></span>
+						</div>
+					</div>
+					<div class="sheet-table">
+						<div class="sheet-table-row">
+							<span class="sheet-table-header">Concentration Check</span>
+							<span class="sheet-table-header">Total</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">Ability</span>
+							<span class="sheet-table-header">Mod</span>
+							<span class="sheet-table-header"></span>
+							<span class="sheet-table-header">Misc</span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Concentration-Check-1}" type="roll" value="&{template:pf_check} {{name=Concentration Check}} {{caster_class=@{spellclass-1-name} [[@{spellclass-1-level}]] }} {{concentration_chk=[[1d20 + @{Concentration-1}]] }}" name="roll_Concentration-Check-1">Concentration</button></span>
+							<span class="sheet-table-data sheet-center"><input title="@{Concentration-1}" type="number" name="attr_Concentration-1" value="(@{spellclass-1-level} + @{Concentration-1-ability} + @{Concentration-1-misc})" disabled></span>
+							<span class="sheet-table-data sheet-center">=</span>
+							<span class="sheet-table-data sheet-center">
+								<select title="@{Concentration-1-ability}" name="attr_Concentration-1-ability">
+									<option value="0" selected>None</option>
+									<option value="(@{STR-mod})">STR</option>
+									<option value="(@{DEX-mod})">DEX</option>
+									<option value="(@{CON-mod})">CON</option>
+									<option value="(@{INT-mod})">INT</option>
+									<option value="(@{WIS-mod})">WIS</option>
+									<option value="(@{CHA-mod})">CHA</option>
+								</select>
+							</span>
+							<span class="sheet-table-data sheet-center"><input title="@{Concentration-1-mod}" type="number" name="attr_Concentration-1-mod" value="@{Concentration-1-ability}" disabled></span>
+							<span class="sheet-table-data sheet-center">+</span>
+							<span class="sheet-table-data sheet-center"><input title="@{Concentration-1-misc}" type="number" name="attr_Concentration-1-misc" value="0"></span>
+						</div>
+					</div>
+					<div class="sheet-table">
+						<div class="sheet-table-row">
+							<span class="sheet-table-header">Save DC</span>
+							<span class="sheet-table-header">Level</span>
+							<span class="sheet-table-header">Uses</span>
+							<span class="sheet-table-header">Total</span>
+							<span class="sheet-table-header">Spells / Day</span>
+							<span class="sheet-table-header">Bonus Spells</span>
+							<span class="sheet-table-header">Misc</span>
+							<span class="sheet-table-header">Spells Known</span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-0-savedc}" type="number" name="attr_spellclass-1-level-0-savedc" value="(10 + 0 + @{Concentration-1-ability})" disabled></span>
+							<span class="sheet-table-header">0</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-0-spells-per-day}" type="number" name="attr_spellclass-1-level-0-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-0-spells-per-day|max" type="number" name="attr_spellclass-1-level-0-spells-per-day_max" value="(@{spellclass-1-level-0-class} + @{spellclass-1-level-0-misc})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-0-class}" type="number" name="attr_spellclass-1-level-0-class"></span>
+							<span class="sheet-table-data sheet-center">
+								<select title="@{Concentration-1-ability}" name="attr_Concentration-1-ability">
+									<option value="0" selected>None</option>
+									<option value="(@{STR-mod})">STR</option>
+									<option value="(@{DEX-mod})">DEX</option>
+									<option value="(@{CON-mod})">CON</option>
+									<option value="(@{INT-mod})">INT</option>
+									<option value="(@{WIS-mod})">WIS</option>
+									<option value="(@{CHA-mod})">CHA</option>
+								</select>
+							</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-0-misc}" type="number" name="attr_spellclass-1-level-0-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-0-spells-known}" type="number" name="attr_spellclass-1-level-0-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-1-savedc}" type="number" name="attr_spellclass-1-level-1-savedc" value="(10 + 1 + @{Concentration-1-ability})" disabled></span>
+							<span class="sheet-table-header">1st</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-1-spells-per-day}" type="number" name="attr_spellclass-1-level-1-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-1-spells-per-day|max" type="number" name="attr_spellclass-1-level-1-spells-per-day_max" value="(@{spellclass-1-level-1-misc} + @{spellclass-1-level-1-class} + @{spellclass-1-level-1-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-1-class}" type="number" name="attr_spellclass-1-level-1-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-1-bonus}" type="number" name="attr_spellclass-1-level-1-bonus" value="((((ceil(@{Concentration-1-ability}/4) + 0) + abs(ceil(@{Concentration-1-ability}/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-1-misc}" type="number" name="attr_spellclass-1-level-1-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-1-spells-known}" type="number" name="attr_spellclass-1-level-1-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-2-savedc}" type="number" name="attr_spellclass-1-level-2-savedc" value="(10 + 2 + @{Concentration-1-ability})" disabled></span>
+							<span class="sheet-table-header">2nd</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-2-spells-per-day}" type="number" name="attr_spellclass-1-level-2-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-2-spells-per-day|max" type="number" name="attr_spellclass-1-level-2-spells-per-day_max" value="(@{spellclass-1-level-2-misc} + @{spellclass-1-level-2-class} + @{spellclass-1-level-2-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-2-class}" type="number" name="attr_spellclass-1-level-2-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-2-bonus}" type="number" name="attr_spellclass-1-level-2-bonus" value="((((ceil((@{Concentration-1-ability} - 1)/4) + 0) + abs(ceil((@{Concentration-1-ability} - 1)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-2-misc}" type="number" name="attr_spellclass-1-level-2-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-2-spells-known}" type="number" name="attr_spellclass-1-level-2-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-3-savedc}" type="number" name="attr_spellclass-1-level-3-savedc" value="(10 + 3 + @{Concentration-1-ability})" disabled></span>
+							<span class="sheet-table-header">3rd</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-3-spells-per-day}" type="number" name="attr_spellclass-1-level-3-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-3-spells-per-day|max" type="number" name="attr_spellclass-1-level-3-spells-per-day_max" value="(@{spellclass-1-level-3-misc} + @{spellclass-1-level-3-class} + @{spellclass-1-level-3-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-3-class}" type="number" name="attr_spellclass-1-level-3-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-3-bonus}" type="number" name="attr_spellclass-1-level-3-bonus" value="((((ceil((@{Concentration-1-ability} - 2)/4) + 0) + abs(ceil((@{Concentration-1-ability} - 2)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-3-misc}" type="number" name="attr_spellclass-1-level-3-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-3-spells-known}" type="number" name="attr_spellclass-1-level-3-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-4-savedc}" type="number" name="attr_spellclass-1-level-4-savedc" value="(10 + 4 + @{Concentration-1-ability})" disabled></span>
+							<span class="sheet-table-header">4th</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-4-spells-per-day}" type="number" name="attr_spellclass-1-level-4-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-4-spells-per-day|max" type="number" name="attr_spellclass-1-level-4-spells-per-day_max" value="(@{spellclass-1-level-4-misc} + @{spellclass-1-level-4-class} + @{spellclass-1-level-4-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-4-class}" type="number" name="attr_spellclass-1-level-4-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-4-bonus}" type="number" name="attr_spellclass-1-level-4-bonus" value="((((ceil((@{Concentration-1-ability} - 3)/4) + 0) + abs(ceil((@{Concentration-1-ability} - 3)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-4-misc}" type="number" name="attr_spellclass-1-level-4-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-4-spells-known}" type="number" name="attr_spellclass-1-level-4-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-5-savedc}" type="number" name="attr_spellclass-1-level-5-savedc" value="(10 + 5 + @{Concentration-1-ability})" disabled></span>
+							<span class="sheet-table-header">5th</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-5-spells-per-day}" type="number" name="attr_spellclass-1-level-5-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-5-spells-per-day|max" type="number" name="attr_spellclass-1-level-5-spells-per-day_max" value="(@{spellclass-1-level-5-misc} + @{spellclass-1-level-5-class} + @{spellclass-1-level-5-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-5-class}" type="number" name="attr_spellclass-1-level-5-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-5-bonus}" type="number" name="attr_spellclass-1-level-5-bonus" value="((((ceil((@{Concentration-1-ability} - 4)/4) + 0) + abs(ceil((@{Concentration-1-ability} - 4)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-5-misc}" type="number" name="attr_spellclass-1-level-5-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-5-spells-known}" type="number" name="attr_spellclass-1-level-5-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-6-savedc}" type="number" name="attr_spellclass-1-level-6-savedc" value="(10 + 6 + @{Concentration-1-ability})" disabled></span>
+							<span class="sheet-table-header">6th</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-6-spells-per-day}" type="number" name="attr_spellclass-1-level-6-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-6-spells-per-day|max" type="number" name="attr_spellclass-1-level-6-spells-per-day_max" value="(@{spellclass-1-level-6-misc} + @{spellclass-1-level-6-class} + @{spellclass-1-level-6-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-6-class}" type="number" name="attr_spellclass-1-level-6-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-6-bonus}" type="number" name="attr_spellclass-1-level-6-bonus" value="((((ceil((@{Concentration-1-ability} - 5)/4) + 0) + abs(ceil((@{Concentration-1-ability} - 5)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-6-misc}" type="number" name="attr_spellclass-1-level-6-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-6-spells-known}" type="number" name="attr_spellclass-1-level-6-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-7-savedc}" type="number" name="attr_spellclass-1-level-7-savedc" value="(10 + 7 + @{Concentration-1-ability})" disabled></span>
+							<span class="sheet-table-header">7th</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-7-spells-per-day}" type="number" name="attr_spellclass-1-level-7-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-7-spells-per-day|max" type="number" name="attr_spellclass-1-level-7-spells-per-day_max" value="(@{spellclass-1-level-7-misc} + @{spellclass-1-level-7-class} + @{spellclass-1-level-7-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-7-class}" type="number" name="attr_spellclass-1-level-7-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-7-bonus}" type="number" name="attr_spellclass-1-level-7-bonus" value="((((ceil((@{Concentration-1-ability} - 6)/4) + 0) + abs(ceil((@{Concentration-1-ability} - 6)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-7-misc}" type="number" name="attr_spellclass-1-level-7-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-7-spells-known}" type="number" name="attr_spellclass-1-level-7-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-8-savedc}" type="number" name="attr_spellclass-1-level-8-savedc" value="(10 + 8 + @{Concentration-1-ability})" disabled></span>
+							<span class="sheet-table-header">8th</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-8-spells-per-day}" type="number" name="attr_spellclass-1-level-8-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-8-spells-per-day|max" type="number" name="attr_spellclass-1-level-8-spells-per-day_max" value="(@{spellclass-1-level-8-misc} + @{spellclass-1-level-8-class} + @{spellclass-1-level-8-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-8-class}" type="number" name="attr_spellclass-1-level-8-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-8-bonus}" type="number" name="attr_spellclass-1-level-8-bonus" value="((((ceil((@{Concentration-1-ability} - 7)/4) + 0) + abs(ceil((@{Concentration-1-ability} - 7)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-8-misc}" type="number" name="attr_spellclass-1-level-8-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-8-spells-known}" type="number" name="attr_spellclass-1-level-8-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-9-savedc}" type="number" name="attr_spellclass-1-level-9-savedc" value="(10 + 9 + @{Concentration-1-ability})" disabled></span>
+							<span class="sheet-table-header">9th</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-9-spells-per-day}" type="number" name="attr_spellclass-1-level-9-spells-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-9-spells-per-day|max" type="number" name="attr_spellclass-1-level-9-spells-per-day_max" value="(@{spellclass-1-level-9-misc} + @{spellclass-1-level-9-class} + @{spellclass-1-level-9-bonus})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-9-class}" type="number" name="attr_spellclass-1-level-9-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-9-bonus}" type="number" name="attr_spellclass-1-level-9-bonus" value="((((ceil((@{Concentration-1-ability} - 8)/4) + 0) + abs(ceil((@{Concentration-1-ability} - 8)/4) - 0)) / 2))" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-9-misc}" type="number" name="attr_spellclass-1-level-9-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-9-spells-known}" type="number" name="attr_spellclass-1-level-9-spells-known" value="0"></span>
+						</div>
+						<div class="sheet-table-row">
+							<span class="sheet-table-data sheet-center"></span>
+							<span class="sheet-table-header">SP</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-spell-points-per-day}" type="number" name="attr_spellclass-1-spell-points-per-day" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-spell-points-per-day|max" type="number" name="attr_spellclass-1-spell-points-per-day_max" value="(@{spellclass-1-spell-points-class} + @{spellclass-1-spell-points-bonus} + @{spellclass-1-spell-points-misc})" disabled></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-spell-points-class}" type="number" name="attr_spellclass-1-spell-points-class"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-spell-points-bonus}" type="number" name="attr_spellclass-1-spell-points-bonus" value="0"></span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-spell-points-misc}" type="number" name="attr_spellclass-1-spell-points-misc" value="0"></span>
+							<span class="sheet-table-data sheet-center"></span>
+						</div>
+					</div> 
+					<div class="sheet-table">					
+						<div class="sheet-table-row">
+							<span class="sheet-table-row-name">Close</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-close}" type="number" name="attr_spellclass-1-close" value="(25 + (5 * floor(@{spellclass-1-level} / 2)))" disabled></span>
+							<span class="sheet-table-row-name">Medium</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-medium}" type="number" name="attr_spellclass-1-medium" value="(100 + (10 * @{spellclass-1-level}))" disabled></span>
+							<span class="sheet-table-row-name">Long</span>
+							<span class="sheet-table-data sheet-center"><input title="@{spellclass-1-long}" type="number" name="attr_spellclass-1-long" value="(400 + (40 * @{spellclass-1-level}))" disabled></span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<br>
+	</div>
+	<div>
+		<b>Level 0 Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{lvl-0-spells-show}" name="attr_lvl-0-spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Level 0 Spell Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_0_Cast" title="%{selected|repeating_lvl-0-spells_0_Cast}" value="/em casts @{repeating_lvl-0-spells_0_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_0_name}}} {{school=@{repeating_lvl-0-spells_0_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_0_cast-time}}} {{components=@{repeating_lvl-0-spells_0_components}}} {{range=@{repeating_lvl-0-spells_0_range}}} {{target=@{repeating_lvl-0-spells_0_targets}}} {{duration=@{repeating_lvl-0-spells_0_duration}}} {{saving_throw=@{repeating_lvl-0-spells_0_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_0_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_0_sr}}} {{spell_description=@{repeating_lvl-0-spells_0_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_1_Cast" title="%{selected|repeating_lvl-0-spells_1_Cast}" value="/em casts @{repeating_lvl-0-spells_1_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_1_name}}} {{school=@{repeating_lvl-0-spells_1_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_1_cast-time}}} {{components=@{repeating_lvl-0-spells_1_components}}} {{range=@{repeating_lvl-0-spells_1_range}}} {{target=@{repeating_lvl-0-spells_1_targets}}} {{duration=@{repeating_lvl-0-spells_1_duration}}} {{saving_throw=@{repeating_lvl-0-spells_1_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_1_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_1_sr}}} {{spell_description=@{repeating_lvl-0-spells_1_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_2_Cast" title="%{selected|repeating_lvl-0-spells_2_Cast}" value="/em casts @{repeating_lvl-0-spells_2_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_2_name}}} {{school=@{repeating_lvl-0-spells_2_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_2_cast-time}}} {{components=@{repeating_lvl-0-spells_2_components}}} {{range=@{repeating_lvl-0-spells_2_range}}} {{target=@{repeating_lvl-0-spells_2_targets}}} {{duration=@{repeating_lvl-0-spells_2_duration}}} {{saving_throw=@{repeating_lvl-0-spells_2_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_2_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_2_sr}}} {{spell_description=@{repeating_lvl-0-spells_2_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_3_Cast" title="%{selected|repeating_lvl-0-spells_3_Cast}" value="/em casts @{repeating_lvl-0-spells_3_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_3_name}}} {{school=@{repeating_lvl-0-spells_3_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_3_cast-time}}} {{components=@{repeating_lvl-0-spells_3_components}}} {{range=@{repeating_lvl-0-spells_3_range}}} {{target=@{repeating_lvl-0-spells_3_targets}}} {{duration=@{repeating_lvl-0-spells_3_duration}}} {{saving_throw=@{repeating_lvl-0-spells_3_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_3_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_3_sr}}} {{spell_description=@{repeating_lvl-0-spells_3_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_4_Cast" title="%{selected|repeating_lvl-0-spells_4_Cast}" value="/em casts @{repeating_lvl-0-spells_4_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_4_name}}} {{school=@{repeating_lvl-0-spells_4_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_4_cast-time}}} {{components=@{repeating_lvl-0-spells_4_components}}} {{range=@{repeating_lvl-0-spells_4_range}}} {{target=@{repeating_lvl-0-spells_4_targets}}} {{duration=@{repeating_lvl-0-spells_4_duration}}} {{saving_throw=@{repeating_lvl-0-spells_4_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_4_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_4_sr}}} {{spell_description=@{repeating_lvl-0-spells_4_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_5_Cast" title="%{selected|repeating_lvl-0-spells_5_Cast}" value="/em casts @{repeating_lvl-0-spells_5_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_5_name}}} {{school=@{repeating_lvl-0-spells_5_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_5_cast-time}}} {{components=@{repeating_lvl-0-spells_5_components}}} {{range=@{repeating_lvl-0-spells_5_range}}} {{target=@{repeating_lvl-0-spells_5_targets}}} {{duration=@{repeating_lvl-0-spells_5_duration}}} {{saving_throw=@{repeating_lvl-0-spells_5_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_5_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_5_sr}}} {{spell_description=@{repeating_lvl-0-spells_5_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_6_Cast" title="%{selected|repeating_lvl-0-spells_6_Cast}" value="/em casts @{repeating_lvl-0-spells_6_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_6_name}}} {{school=@{repeating_lvl-0-spells_6_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_6_cast-time}}} {{components=@{repeating_lvl-0-spells_6_components}}} {{range=@{repeating_lvl-0-spells_6_range}}} {{target=@{repeating_lvl-0-spells_6_targets}}} {{duration=@{repeating_lvl-0-spells_6_duration}}} {{saving_throw=@{repeating_lvl-0-spells_6_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_6_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_6_sr}}} {{spell_description=@{repeating_lvl-0-spells_6_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_7_Cast" title="%{selected|repeating_lvl-0-spells_7_Cast}" value="/em casts @{repeating_lvl-0-spells_7_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_7_name}}} {{school=@{repeating_lvl-0-spells_7_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_7_cast-time}}} {{components=@{repeating_lvl-0-spells_7_components}}} {{range=@{repeating_lvl-0-spells_7_range}}} {{target=@{repeating_lvl-0-spells_7_targets}}} {{duration=@{repeating_lvl-0-spells_7_duration}}} {{saving_throw=@{repeating_lvl-0-spells_7_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_7_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_7_sr}}} {{spell_description=@{repeating_lvl-0-spells_7_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_8_Cast" title="%{selected|repeating_lvl-0-spells_8_Cast}" value="/em casts @{repeating_lvl-0-spells_8_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_8_name}}} {{school=@{repeating_lvl-0-spells_8_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_8_cast-time}}} {{components=@{repeating_lvl-0-spells_8_components}}} {{range=@{repeating_lvl-0-spells_8_range}}} {{target=@{repeating_lvl-0-spells_8_targets}}} {{duration=@{repeating_lvl-0-spells_8_duration}}} {{saving_throw=@{repeating_lvl-0-spells_8_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_8_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_8_sr}}} {{spell_description=@{repeating_lvl-0-spells_8_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_9_Cast" title="%{selected|repeating_lvl-0-spells_9_Cast}" value="/em casts @{repeating_lvl-0-spells_9_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_9_name}}} {{school=@{repeating_lvl-0-spells_9_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_9_cast-time}}} {{components=@{repeating_lvl-0-spells_9_components}}} {{range=@{repeating_lvl-0-spells_9_range}}} {{target=@{repeating_lvl-0-spells_9_targets}}} {{duration=@{repeating_lvl-0-spells_9_duration}}} {{saving_throw=@{repeating_lvl-0-spells_9_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_9_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_9_sr}}} {{spell_description=@{repeating_lvl-0-spells_9_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_10_Cast" title="%{selected|repeating_lvl-0-spells_10_Cast}" value="/em casts @{repeating_lvl-0-spells_10_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_10_name}}} {{school=@{repeating_lvl-0-spells_10_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_10_cast-time}}} {{components=@{repeating_lvl-0-spells_10_components}}} {{range=@{repeating_lvl-0-spells_10_range}}} {{target=@{repeating_lvl-0-spells_10_targets}}} {{duration=@{repeating_lvl-0-spells_10_duration}}} {{saving_throw=@{repeating_lvl-0-spells_10_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_10_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_10_sr}}} {{spell_description=@{repeating_lvl-0-spells_10_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_11_Cast" title="%{selected|repeating_lvl-0-spells_11_Cast}" value="/em casts @{repeating_lvl-0-spells_11_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_11_name}}} {{school=@{repeating_lvl-0-spells_11_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_11_cast-time}}} {{components=@{repeating_lvl-0-spells_11_components}}} {{range=@{repeating_lvl-0-spells_11_range}}} {{target=@{repeating_lvl-0-spells_11_targets}}} {{duration=@{repeating_lvl-0-spells_11_duration}}} {{saving_throw=@{repeating_lvl-0-spells_11_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_11_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_11_sr}}} {{spell_description=@{repeating_lvl-0-spells_11_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_12_Cast" title="%{selected|repeating_lvl-0-spells_12_Cast}" value="/em casts @{repeating_lvl-0-spells_12_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_12_name}}} {{school=@{repeating_lvl-0-spells_12_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_12_cast-time}}} {{components=@{repeating_lvl-0-spells_12_components}}} {{range=@{repeating_lvl-0-spells_12_range}}} {{target=@{repeating_lvl-0-spells_12_targets}}} {{duration=@{repeating_lvl-0-spells_12_duration}}} {{saving_throw=@{repeating_lvl-0-spells_12_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_12_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_12_sr}}} {{spell_description=@{repeating_lvl-0-spells_12_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_13_Cast" title="%{selected|repeating_lvl-0-spells_13_Cast}" value="/em casts @{repeating_lvl-0-spells_13_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_13_name}}} {{school=@{repeating_lvl-0-spells_13_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_13_cast-time}}} {{components=@{repeating_lvl-0-spells_13_components}}} {{range=@{repeating_lvl-0-spells_13_range}}} {{target=@{repeating_lvl-0-spells_13_targets}}} {{duration=@{repeating_lvl-0-spells_13_duration}}} {{saving_throw=@{repeating_lvl-0-spells_13_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_13_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_13_sr}}} {{spell_description=@{repeating_lvl-0-spells_13_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_14_Cast" title="%{selected|repeating_lvl-0-spells_14_Cast}" value="/em casts @{repeating_lvl-0-spells_14_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_14_name}}} {{school=@{repeating_lvl-0-spells_14_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_14_cast-time}}} {{components=@{repeating_lvl-0-spells_14_components}}} {{range=@{repeating_lvl-0-spells_14_range}}} {{target=@{repeating_lvl-0-spells_14_targets}}} {{duration=@{repeating_lvl-0-spells_14_duration}}} {{saving_throw=@{repeating_lvl-0-spells_14_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_14_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_14_sr}}} {{spell_description=@{repeating_lvl-0-spells_14_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_15_Cast" title="%{selected|repeating_lvl-0-spells_15_Cast}" value="/em casts @{repeating_lvl-0-spells_15_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_15_name}}} {{school=@{repeating_lvl-0-spells_15_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_15_cast-time}}} {{components=@{repeating_lvl-0-spells_15_components}}} {{range=@{repeating_lvl-0-spells_15_range}}} {{target=@{repeating_lvl-0-spells_15_targets}}} {{duration=@{repeating_lvl-0-spells_15_duration}}} {{saving_throw=@{repeating_lvl-0-spells_15_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_15_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_15_sr}}} {{spell_description=@{repeating_lvl-0-spells_15_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_16_Cast" title="%{selected|repeating_lvl-0-spells_16_Cast}" value="/em casts @{repeating_lvl-0-spells_16_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_16_name}}} {{school=@{repeating_lvl-0-spells_16_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_16_cast-time}}} {{components=@{repeating_lvl-0-spells_16_components}}} {{range=@{repeating_lvl-0-spells_16_range}}} {{target=@{repeating_lvl-0-spells_16_targets}}} {{duration=@{repeating_lvl-0-spells_16_duration}}} {{saving_throw=@{repeating_lvl-0-spells_16_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_16_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_16_sr}}} {{spell_description=@{repeating_lvl-0-spells_16_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_17_Cast" title="%{selected|repeating_lvl-0-spells_17_Cast}" value="/em casts @{repeating_lvl-0-spells_17_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_17_name}}} {{school=@{repeating_lvl-0-spells_17_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_17_cast-time}}} {{components=@{repeating_lvl-0-spells_17_components}}} {{range=@{repeating_lvl-0-spells_17_range}}} {{target=@{repeating_lvl-0-spells_17_targets}}} {{duration=@{repeating_lvl-0-spells_17_duration}}} {{saving_throw=@{repeating_lvl-0-spells_17_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_17_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_17_sr}}} {{spell_description=@{repeating_lvl-0-spells_17_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_18_Cast" title="%{selected|repeating_lvl-0-spells_18_Cast}" value="/em casts @{repeating_lvl-0-spells_18_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_18_name}}} {{school=@{repeating_lvl-0-spells_18_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_18_cast-time}}} {{components=@{repeating_lvl-0-spells_18_components}}} {{range=@{repeating_lvl-0-spells_18_range}}} {{target=@{repeating_lvl-0-spells_18_targets}}} {{duration=@{repeating_lvl-0-spells_18_duration}}} {{saving_throw=@{repeating_lvl-0-spells_18_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_18_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_18_sr}}} {{spell_description=@{repeating_lvl-0-spells_18_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_19_Cast" title="%{selected|repeating_lvl-0-spells_19_Cast}" value="/em casts @{repeating_lvl-0-spells_19_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_19_name}}} {{school=@{repeating_lvl-0-spells_19_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_19_cast-time}}} {{components=@{repeating_lvl-0-spells_19_components}}} {{range=@{repeating_lvl-0-spells_19_range}}} {{target=@{repeating_lvl-0-spells_19_targets}}} {{duration=@{repeating_lvl-0-spells_19_duration}}} {{saving_throw=@{repeating_lvl-0-spells_19_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_19_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_19_sr}}} {{spell_description=@{repeating_lvl-0-spells_19_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_20_Cast" title="%{selected|repeating_lvl-0-spells_20_Cast}" value="/em casts @{repeating_lvl-0-spells_20_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_20_name}}} {{school=@{repeating_lvl-0-spells_20_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_20_cast-time}}} {{components=@{repeating_lvl-0-spells_20_components}}} {{range=@{repeating_lvl-0-spells_20_range}}} {{target=@{repeating_lvl-0-spells_20_targets}}} {{duration=@{repeating_lvl-0-spells_20_duration}}} {{saving_throw=@{repeating_lvl-0-spells_20_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_20_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_20_sr}}} {{spell_description=@{repeating_lvl-0-spells_20_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_21_Cast" title="%{selected|repeating_lvl-0-spells_21_Cast}" value="/em casts @{repeating_lvl-0-spells_21_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_21_name}}} {{school=@{repeating_lvl-0-spells_21_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_21_cast-time}}} {{components=@{repeating_lvl-0-spells_21_components}}} {{range=@{repeating_lvl-0-spells_21_range}}} {{target=@{repeating_lvl-0-spells_21_targets}}} {{duration=@{repeating_lvl-0-spells_21_duration}}} {{saving_throw=@{repeating_lvl-0-spells_21_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_21_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_21_sr}}} {{spell_description=@{repeating_lvl-0-spells_21_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_22_Cast" title="%{selected|repeating_lvl-0-spells_22_Cast}" value="/em casts @{repeating_lvl-0-spells_22_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_22_name}}} {{school=@{repeating_lvl-0-spells_22_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_22_cast-time}}} {{components=@{repeating_lvl-0-spells_22_components}}} {{range=@{repeating_lvl-0-spells_22_range}}} {{target=@{repeating_lvl-0-spells_22_targets}}} {{duration=@{repeating_lvl-0-spells_22_duration}}} {{saving_throw=@{repeating_lvl-0-spells_22_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_22_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_22_sr}}} {{spell_description=@{repeating_lvl-0-spells_22_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_23_Cast" title="%{selected|repeating_lvl-0-spells_23_Cast}" value="/em casts @{repeating_lvl-0-spells_23_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_23_name}}} {{school=@{repeating_lvl-0-spells_23_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_23_cast-time}}} {{components=@{repeating_lvl-0-spells_23_components}}} {{range=@{repeating_lvl-0-spells_23_range}}} {{target=@{repeating_lvl-0-spells_23_targets}}} {{duration=@{repeating_lvl-0-spells_23_duration}}} {{saving_throw=@{repeating_lvl-0-spells_23_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_23_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_23_sr}}} {{spell_description=@{repeating_lvl-0-spells_23_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_24_Cast" title="%{selected|repeating_lvl-0-spells_24_Cast}" value="/em casts @{repeating_lvl-0-spells_24_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_24_name}}} {{school=@{repeating_lvl-0-spells_24_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_24_cast-time}}} {{components=@{repeating_lvl-0-spells_24_components}}} {{range=@{repeating_lvl-0-spells_24_range}}} {{target=@{repeating_lvl-0-spells_24_targets}}} {{duration=@{repeating_lvl-0-spells_24_duration}}} {{saving_throw=@{repeating_lvl-0-spells_24_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_24_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_24_sr}}} {{spell_description=@{repeating_lvl-0-spells_24_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_25_Cast" title="%{selected|repeating_lvl-0-spells_25_Cast}" value="/em casts @{repeating_lvl-0-spells_25_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_25_name}}} {{school=@{repeating_lvl-0-spells_25_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_25_cast-time}}} {{components=@{repeating_lvl-0-spells_25_components}}} {{range=@{repeating_lvl-0-spells_25_range}}} {{target=@{repeating_lvl-0-spells_25_targets}}} {{duration=@{repeating_lvl-0-spells_25_duration}}} {{saving_throw=@{repeating_lvl-0-spells_25_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_25_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_25_sr}}} {{spell_description=@{repeating_lvl-0-spells_25_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_26_Cast" title="%{selected|repeating_lvl-0-spells_26_Cast}" value="/em casts @{repeating_lvl-0-spells_26_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-0-spells_26_name}}} {{school=@{repeating_lvl-0-spells_26_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-0-spells_26_cast-time}}} {{components=@{repeating_lvl-0-spells_26_components}}} {{range=@{repeating_lvl-0-spells_26_range}}} {{target=@{repeating_lvl-0-spells_26_targets}}} {{duration=@{repeating_lvl-0-spells_26_duration}}} {{saving_throw=@{repeating_lvl-0-spells_26_save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{repeating_lvl-0-spells_26_DC-mod}]]}} {{sr=@{repeating_lvl-0-spells_26_sr}}} {{spell_description=@{repeating_lvl-0-spells_26_description}}}"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-sect">
+			<div class="sheet-table">
+				<span class="sheet-table-name">Level 0 Spells</span>
+			</div>
+			<fieldset class="repeating_lvl-0-spells">
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
+                </div>
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>					
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_duration}" type="text" value="N/A" name="attr_duration" placeholder="Duration"><br>Duration</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
+					<span class="sheet-table-data sheet-center sheet-small-label">
+						<select title="@{repeating_lvl-0-spells_X_sr}" name="attr_sr">
+							<option value="" selected>Select SR</option>
+							<option value="Yes">Yes</option>
+							<option value="No">No</option>
+						</select>
+						<br>SR
+					</span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-0-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_lvl-0-spells_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-0-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-0-spells_X_macro-text}" name="attr_macro-text">/em casts @{name}!&#x00A;&{template:pf_spell} {{name=@{name}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[@{spellclass-0-level-0-savedc} + @{DC-mod}]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+    <div>
+		<b>Level 1 Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{lvl-1-spells-show}" name="attr_lvl-1-spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Level 1 Spell Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_0_Cast" title="%{selected|repeating_lvl-1-spells_0_Cast}" value="/em casts @{repeating_lvl-1-spells_0_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_0_name}}} {{school=@{repeating_lvl-1-spells_0_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_0_cast-time}}} {{components=@{repeating_lvl-1-spells_0_components}}} {{range=@{repeating_lvl-1-spells_0_range}}} {{target=@{repeating_lvl-1-spells_0_targets}}} {{duration=@{repeating_lvl-1-spells_0_duration}}} {{saving_throw=@{repeating_lvl-1-spells_0_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_0_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_0_sr}}} {{spell_description=@{repeating_lvl-1-spells_0_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_1_Cast" title="%{selected|repeating_lvl-1-spells_1_Cast}" value="/em casts @{repeating_lvl-1-spells_1_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_1_name}}} {{school=@{repeating_lvl-1-spells_1_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_1_cast-time}}} {{components=@{repeating_lvl-1-spells_1_components}}} {{range=@{repeating_lvl-1-spells_1_range}}} {{target=@{repeating_lvl-1-spells_1_targets}}} {{duration=@{repeating_lvl-1-spells_1_duration}}} {{saving_throw=@{repeating_lvl-1-spells_1_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_1_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_1_sr}}} {{spell_description=@{repeating_lvl-1-spells_1_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_2_Cast" title="%{selected|repeating_lvl-1-spells_2_Cast}" value="/em casts @{repeating_lvl-1-spells_2_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_2_name}}} {{school=@{repeating_lvl-1-spells_2_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_2_cast-time}}} {{components=@{repeating_lvl-1-spells_2_components}}} {{range=@{repeating_lvl-1-spells_2_range}}} {{target=@{repeating_lvl-1-spells_2_targets}}} {{duration=@{repeating_lvl-1-spells_2_duration}}} {{saving_throw=@{repeating_lvl-1-spells_2_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_2_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_2_sr}}} {{spell_description=@{repeating_lvl-1-spells_2_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_3_Cast" title="%{selected|repeating_lvl-1-spells_3_Cast}" value="/em casts @{repeating_lvl-1-spells_3_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_3_name}}} {{school=@{repeating_lvl-1-spells_3_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_3_cast-time}}} {{components=@{repeating_lvl-1-spells_3_components}}} {{range=@{repeating_lvl-1-spells_3_range}}} {{target=@{repeating_lvl-1-spells_3_targets}}} {{duration=@{repeating_lvl-1-spells_3_duration}}} {{saving_throw=@{repeating_lvl-1-spells_3_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_3_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_3_sr}}} {{spell_description=@{repeating_lvl-1-spells_3_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_4_Cast" title="%{selected|repeating_lvl-1-spells_4_Cast}" value="/em casts @{repeating_lvl-1-spells_4_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_4_name}}} {{school=@{repeating_lvl-1-spells_4_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_4_cast-time}}} {{components=@{repeating_lvl-1-spells_4_components}}} {{range=@{repeating_lvl-1-spells_4_range}}} {{target=@{repeating_lvl-1-spells_4_targets}}} {{duration=@{repeating_lvl-1-spells_4_duration}}} {{saving_throw=@{repeating_lvl-1-spells_4_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_4_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_4_sr}}} {{spell_description=@{repeating_lvl-1-spells_4_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_5_Cast" title="%{selected|repeating_lvl-1-spells_5_Cast}" value="/em casts @{repeating_lvl-1-spells_5_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_5_name}}} {{school=@{repeating_lvl-1-spells_5_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_5_cast-time}}} {{components=@{repeating_lvl-1-spells_5_components}}} {{range=@{repeating_lvl-1-spells_5_range}}} {{target=@{repeating_lvl-1-spells_5_targets}}} {{duration=@{repeating_lvl-1-spells_5_duration}}} {{saving_throw=@{repeating_lvl-1-spells_5_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_5_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_5_sr}}} {{spell_description=@{repeating_lvl-1-spells_5_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_6_Cast" title="%{selected|repeating_lvl-1-spells_6_Cast}" value="/em casts @{repeating_lvl-1-spells_6_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_6_name}}} {{school=@{repeating_lvl-1-spells_6_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_6_cast-time}}} {{components=@{repeating_lvl-1-spells_6_components}}} {{range=@{repeating_lvl-1-spells_6_range}}} {{target=@{repeating_lvl-1-spells_6_targets}}} {{duration=@{repeating_lvl-1-spells_6_duration}}} {{saving_throw=@{repeating_lvl-1-spells_6_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_6_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_6_sr}}} {{spell_description=@{repeating_lvl-1-spells_6_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_7_Cast" title="%{selected|repeating_lvl-1-spells_7_Cast}" value="/em casts @{repeating_lvl-1-spells_7_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_7_name}}} {{school=@{repeating_lvl-1-spells_7_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_7_cast-time}}} {{components=@{repeating_lvl-1-spells_7_components}}} {{range=@{repeating_lvl-1-spells_7_range}}} {{target=@{repeating_lvl-1-spells_7_targets}}} {{duration=@{repeating_lvl-1-spells_7_duration}}} {{saving_throw=@{repeating_lvl-1-spells_7_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_7_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_7_sr}}} {{spell_description=@{repeating_lvl-1-spells_7_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_8_Cast" title="%{selected|repeating_lvl-1-spells_8_Cast}" value="/em casts @{repeating_lvl-1-spells_8_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_8_name}}} {{school=@{repeating_lvl-1-spells_8_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_8_cast-time}}} {{components=@{repeating_lvl-1-spells_8_components}}} {{range=@{repeating_lvl-1-spells_8_range}}} {{target=@{repeating_lvl-1-spells_8_targets}}} {{duration=@{repeating_lvl-1-spells_8_duration}}} {{saving_throw=@{repeating_lvl-1-spells_8_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_8_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_8_sr}}} {{spell_description=@{repeating_lvl-1-spells_8_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_9_Cast" title="%{selected|repeating_lvl-1-spells_9_Cast}" value="/em casts @{repeating_lvl-1-spells_9_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_9_name}}} {{school=@{repeating_lvl-1-spells_9_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_9_cast-time}}} {{components=@{repeating_lvl-1-spells_9_components}}} {{range=@{repeating_lvl-1-spells_9_range}}} {{target=@{repeating_lvl-1-spells_9_targets}}} {{duration=@{repeating_lvl-1-spells_9_duration}}} {{saving_throw=@{repeating_lvl-1-spells_9_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_9_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_9_sr}}} {{spell_description=@{repeating_lvl-1-spells_9_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_10_Cast" title="%{selected|repeating_lvl-1-spells_10_Cast}" value="/em casts @{repeating_lvl-1-spells_10_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_10_name}}} {{school=@{repeating_lvl-1-spells_10_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_10_cast-time}}} {{components=@{repeating_lvl-1-spells_10_components}}} {{range=@{repeating_lvl-1-spells_10_range}}} {{target=@{repeating_lvl-1-spells_10_targets}}} {{duration=@{repeating_lvl-1-spells_10_duration}}} {{saving_throw=@{repeating_lvl-1-spells_10_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_10_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_10_sr}}} {{spell_description=@{repeating_lvl-1-spells_10_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_11_Cast" title="%{selected|repeating_lvl-1-spells_11_Cast}" value="/em casts @{repeating_lvl-1-spells_11_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_11_name}}} {{school=@{repeating_lvl-1-spells_11_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_11_cast-time}}} {{components=@{repeating_lvl-1-spells_11_components}}} {{range=@{repeating_lvl-1-spells_11_range}}} {{target=@{repeating_lvl-1-spells_11_targets}}} {{duration=@{repeating_lvl-1-spells_11_duration}}} {{saving_throw=@{repeating_lvl-1-spells_11_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_11_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_11_sr}}} {{spell_description=@{repeating_lvl-1-spells_11_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_12_Cast" title="%{selected|repeating_lvl-1-spells_12_Cast}" value="/em casts @{repeating_lvl-1-spells_12_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_12_name}}} {{school=@{repeating_lvl-1-spells_12_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_12_cast-time}}} {{components=@{repeating_lvl-1-spells_12_components}}} {{range=@{repeating_lvl-1-spells_12_range}}} {{target=@{repeating_lvl-1-spells_12_targets}}} {{duration=@{repeating_lvl-1-spells_12_duration}}} {{saving_throw=@{repeating_lvl-1-spells_12_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_12_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_12_sr}}} {{spell_description=@{repeating_lvl-1-spells_12_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_13_Cast" title="%{selected|repeating_lvl-1-spells_13_Cast}" value="/em casts @{repeating_lvl-1-spells_13_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_13_name}}} {{school=@{repeating_lvl-1-spells_13_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_13_cast-time}}} {{components=@{repeating_lvl-1-spells_13_components}}} {{range=@{repeating_lvl-1-spells_13_range}}} {{target=@{repeating_lvl-1-spells_13_targets}}} {{duration=@{repeating_lvl-1-spells_13_duration}}} {{saving_throw=@{repeating_lvl-1-spells_13_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_13_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_13_sr}}} {{spell_description=@{repeating_lvl-1-spells_13_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_14_Cast" title="%{selected|repeating_lvl-1-spells_14_Cast}" value="/em casts @{repeating_lvl-1-spells_14_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_14_name}}} {{school=@{repeating_lvl-1-spells_14_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_14_cast-time}}} {{components=@{repeating_lvl-1-spells_14_components}}} {{range=@{repeating_lvl-1-spells_14_range}}} {{target=@{repeating_lvl-1-spells_14_targets}}} {{duration=@{repeating_lvl-1-spells_14_duration}}} {{saving_throw=@{repeating_lvl-1-spells_14_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_14_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_14_sr}}} {{spell_description=@{repeating_lvl-1-spells_14_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_15_Cast" title="%{selected|repeating_lvl-1-spells_15_Cast}" value="/em casts @{repeating_lvl-1-spells_15_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_15_name}}} {{school=@{repeating_lvl-1-spells_15_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_15_cast-time}}} {{components=@{repeating_lvl-1-spells_15_components}}} {{range=@{repeating_lvl-1-spells_15_range}}} {{target=@{repeating_lvl-1-spells_15_targets}}} {{duration=@{repeating_lvl-1-spells_15_duration}}} {{saving_throw=@{repeating_lvl-1-spells_15_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_15_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_15_sr}}} {{spell_description=@{repeating_lvl-1-spells_15_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_16_Cast" title="%{selected|repeating_lvl-1-spells_16_Cast}" value="/em casts @{repeating_lvl-1-spells_16_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_16_name}}} {{school=@{repeating_lvl-1-spells_16_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_16_cast-time}}} {{components=@{repeating_lvl-1-spells_16_components}}} {{range=@{repeating_lvl-1-spells_16_range}}} {{target=@{repeating_lvl-1-spells_16_targets}}} {{duration=@{repeating_lvl-1-spells_16_duration}}} {{saving_throw=@{repeating_lvl-1-spells_16_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_16_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_16_sr}}} {{spell_description=@{repeating_lvl-1-spells_16_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_17_Cast" title="%{selected|repeating_lvl-1-spells_17_Cast}" value="/em casts @{repeating_lvl-1-spells_17_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_17_name}}} {{school=@{repeating_lvl-1-spells_17_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_17_cast-time}}} {{components=@{repeating_lvl-1-spells_17_components}}} {{range=@{repeating_lvl-1-spells_17_range}}} {{target=@{repeating_lvl-1-spells_17_targets}}} {{duration=@{repeating_lvl-1-spells_17_duration}}} {{saving_throw=@{repeating_lvl-1-spells_17_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_17_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_17_sr}}} {{spell_description=@{repeating_lvl-1-spells_17_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_18_Cast" title="%{selected|repeating_lvl-1-spells_18_Cast}" value="/em casts @{repeating_lvl-1-spells_18_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_18_name}}} {{school=@{repeating_lvl-1-spells_18_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_18_cast-time}}} {{components=@{repeating_lvl-1-spells_18_components}}} {{range=@{repeating_lvl-1-spells_18_range}}} {{target=@{repeating_lvl-1-spells_18_targets}}} {{duration=@{repeating_lvl-1-spells_18_duration}}} {{saving_throw=@{repeating_lvl-1-spells_18_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_18_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_18_sr}}} {{spell_description=@{repeating_lvl-1-spells_18_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_19_Cast" title="%{selected|repeating_lvl-1-spells_19_Cast}" value="/em casts @{repeating_lvl-1-spells_19_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_19_name}}} {{school=@{repeating_lvl-1-spells_19_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_19_cast-time}}} {{components=@{repeating_lvl-1-spells_19_components}}} {{range=@{repeating_lvl-1-spells_19_range}}} {{target=@{repeating_lvl-1-spells_19_targets}}} {{duration=@{repeating_lvl-1-spells_19_duration}}} {{saving_throw=@{repeating_lvl-1-spells_19_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_19_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_19_sr}}} {{spell_description=@{repeating_lvl-1-spells_19_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_20_Cast" title="%{selected|repeating_lvl-1-spells_20_Cast}" value="/em casts @{repeating_lvl-1-spells_20_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_20_name}}} {{school=@{repeating_lvl-1-spells_20_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_20_cast-time}}} {{components=@{repeating_lvl-1-spells_20_components}}} {{range=@{repeating_lvl-1-spells_20_range}}} {{target=@{repeating_lvl-1-spells_20_targets}}} {{duration=@{repeating_lvl-1-spells_20_duration}}} {{saving_throw=@{repeating_lvl-1-spells_20_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_20_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_20_sr}}} {{spell_description=@{repeating_lvl-1-spells_20_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_21_Cast" title="%{selected|repeating_lvl-1-spells_21_Cast}" value="/em casts @{repeating_lvl-1-spells_21_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_21_name}}} {{school=@{repeating_lvl-1-spells_21_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_21_cast-time}}} {{components=@{repeating_lvl-1-spells_21_components}}} {{range=@{repeating_lvl-1-spells_21_range}}} {{target=@{repeating_lvl-1-spells_21_targets}}} {{duration=@{repeating_lvl-1-spells_21_duration}}} {{saving_throw=@{repeating_lvl-1-spells_21_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_21_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_21_sr}}} {{spell_description=@{repeating_lvl-1-spells_21_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_22_Cast" title="%{selected|repeating_lvl-1-spells_22_Cast}" value="/em casts @{repeating_lvl-1-spells_22_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_22_name}}} {{school=@{repeating_lvl-1-spells_22_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_22_cast-time}}} {{components=@{repeating_lvl-1-spells_22_components}}} {{range=@{repeating_lvl-1-spells_22_range}}} {{target=@{repeating_lvl-1-spells_22_targets}}} {{duration=@{repeating_lvl-1-spells_22_duration}}} {{saving_throw=@{repeating_lvl-1-spells_22_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_22_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_22_sr}}} {{spell_description=@{repeating_lvl-1-spells_22_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_23_Cast" title="%{selected|repeating_lvl-1-spells_23_Cast}" value="/em casts @{repeating_lvl-1-spells_23_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_23_name}}} {{school=@{repeating_lvl-1-spells_23_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_23_cast-time}}} {{components=@{repeating_lvl-1-spells_23_components}}} {{range=@{repeating_lvl-1-spells_23_range}}} {{target=@{repeating_lvl-1-spells_23_targets}}} {{duration=@{repeating_lvl-1-spells_23_duration}}} {{saving_throw=@{repeating_lvl-1-spells_23_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_23_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_23_sr}}} {{spell_description=@{repeating_lvl-1-spells_23_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_24_Cast" title="%{selected|repeating_lvl-1-spells_24_Cast}" value="/em casts @{repeating_lvl-1-spells_24_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_24_name}}} {{school=@{repeating_lvl-1-spells_24_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_24_cast-time}}} {{components=@{repeating_lvl-1-spells_24_components}}} {{range=@{repeating_lvl-1-spells_24_range}}} {{target=@{repeating_lvl-1-spells_24_targets}}} {{duration=@{repeating_lvl-1-spells_24_duration}}} {{saving_throw=@{repeating_lvl-1-spells_24_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_24_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_24_sr}}} {{spell_description=@{repeating_lvl-1-spells_24_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_25_Cast" title="%{selected|repeating_lvl-1-spells_25_Cast}" value="/em casts @{repeating_lvl-1-spells_25_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_25_name}}} {{school=@{repeating_lvl-1-spells_25_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_25_cast-time}}} {{components=@{repeating_lvl-1-spells_25_components}}} {{range=@{repeating_lvl-1-spells_25_range}}} {{target=@{repeating_lvl-1-spells_25_targets}}} {{duration=@{repeating_lvl-1-spells_25_duration}}} {{saving_throw=@{repeating_lvl-1-spells_25_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_25_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_25_sr}}} {{spell_description=@{repeating_lvl-1-spells_25_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-1-spells_26_Cast" title="%{selected|repeating_lvl-1-spells_26_Cast}" value="/em casts @{repeating_lvl-1-spells_26_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-1-spells_26_name}}} {{school=@{repeating_lvl-1-spells_26_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-1-spells_26_cast-time}}} {{components=@{repeating_lvl-1-spells_26_components}}} {{range=@{repeating_lvl-1-spells_26_range}}} {{target=@{repeating_lvl-1-spells_26_targets}}} {{duration=@{repeating_lvl-1-spells_26_duration}}} {{saving_throw=@{repeating_lvl-1-spells_26_save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{repeating_lvl-1-spells_26_DC-mod}]]}} {{sr=@{repeating_lvl-1-spells_26_sr}}} {{spell_description=@{repeating_lvl-1-spells_26_description}}}"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-sect">
+			<div class="sheet-table">
+				<span class="sheet-table-name">Level 1 Spells</span>
+			</div>
+			<fieldset class="repeating_lvl-1-spells">
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
+                </div>
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>					
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_duration}" type="text" value="N/A" name="attr_duration" placeholder="Duration"><br>Duration</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
+					<span class="sheet-table-data sheet-center sheet-small-label">
+						<select title="@{repeating_lvl-1-spells_X_sr}" name="attr_sr">
+							<option value="" selected>Select SR</option>
+							<option value="Yes">Yes</option>
+							<option value="No">No</option>
+						</select>
+						<br>SR
+					</span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-1-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_lvl-1-spells_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-1-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-1-spells_X_macro-text}" name="attr_macro-text">/em casts @{name}!&#x00A;&{template:pf_spell} {{name=@{name}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[@{spellclass-0-level-1-savedc} + @{DC-mod}]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+	<div>
+		<b>Level 2 Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{lvl-2-spells-show}" name="attr_lvl-2-spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Level 2 Spell Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_0_Cast" title="%{selected|repeating_lvl-2-spells_0_Cast}" value="/em casts @{repeating_lvl-2-spells_0_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_0_name}}} {{school=@{repeating_lvl-2-spells_0_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_0_cast-time}}} {{components=@{repeating_lvl-2-spells_0_components}}} {{range=@{repeating_lvl-2-spells_0_range}}} {{target=@{repeating_lvl-2-spells_0_targets}}} {{duration=@{repeating_lvl-2-spells_0_duration}}} {{saving_throw=@{repeating_lvl-2-spells_0_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_0_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_0_sr}}} {{spell_description=@{repeating_lvl-2-spells_0_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_1_Cast" title="%{selected|repeating_lvl-2-spells_1_Cast}" value="/em casts @{repeating_lvl-2-spells_1_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_1_name}}} {{school=@{repeating_lvl-2-spells_1_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_1_cast-time}}} {{components=@{repeating_lvl-2-spells_1_components}}} {{range=@{repeating_lvl-2-spells_1_range}}} {{target=@{repeating_lvl-2-spells_1_targets}}} {{duration=@{repeating_lvl-2-spells_1_duration}}} {{saving_throw=@{repeating_lvl-2-spells_1_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_1_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_1_sr}}} {{spell_description=@{repeating_lvl-2-spells_1_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_2_Cast" title="%{selected|repeating_lvl-2-spells_2_Cast}" value="/em casts @{repeating_lvl-2-spells_2_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_2_name}}} {{school=@{repeating_lvl-2-spells_2_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_2_cast-time}}} {{components=@{repeating_lvl-2-spells_2_components}}} {{range=@{repeating_lvl-2-spells_2_range}}} {{target=@{repeating_lvl-2-spells_2_targets}}} {{duration=@{repeating_lvl-2-spells_2_duration}}} {{saving_throw=@{repeating_lvl-2-spells_2_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_2_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_2_sr}}} {{spell_description=@{repeating_lvl-2-spells_2_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_3_Cast" title="%{selected|repeating_lvl-2-spells_3_Cast}" value="/em casts @{repeating_lvl-2-spells_3_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_3_name}}} {{school=@{repeating_lvl-2-spells_3_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_3_cast-time}}} {{components=@{repeating_lvl-2-spells_3_components}}} {{range=@{repeating_lvl-2-spells_3_range}}} {{target=@{repeating_lvl-2-spells_3_targets}}} {{duration=@{repeating_lvl-2-spells_3_duration}}} {{saving_throw=@{repeating_lvl-2-spells_3_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_3_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_3_sr}}} {{spell_description=@{repeating_lvl-2-spells_3_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_4_Cast" title="%{selected|repeating_lvl-2-spells_4_Cast}" value="/em casts @{repeating_lvl-2-spells_4_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_4_name}}} {{school=@{repeating_lvl-2-spells_4_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_4_cast-time}}} {{components=@{repeating_lvl-2-spells_4_components}}} {{range=@{repeating_lvl-2-spells_4_range}}} {{target=@{repeating_lvl-2-spells_4_targets}}} {{duration=@{repeating_lvl-2-spells_4_duration}}} {{saving_throw=@{repeating_lvl-2-spells_4_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_4_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_4_sr}}} {{spell_description=@{repeating_lvl-2-spells_4_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_5_Cast" title="%{selected|repeating_lvl-2-spells_5_Cast}" value="/em casts @{repeating_lvl-2-spells_5_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_5_name}}} {{school=@{repeating_lvl-2-spells_5_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_5_cast-time}}} {{components=@{repeating_lvl-2-spells_5_components}}} {{range=@{repeating_lvl-2-spells_5_range}}} {{target=@{repeating_lvl-2-spells_5_targets}}} {{duration=@{repeating_lvl-2-spells_5_duration}}} {{saving_throw=@{repeating_lvl-2-spells_5_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_5_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_5_sr}}} {{spell_description=@{repeating_lvl-2-spells_5_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_6_Cast" title="%{selected|repeating_lvl-2-spells_6_Cast}" value="/em casts @{repeating_lvl-2-spells_6_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_6_name}}} {{school=@{repeating_lvl-2-spells_6_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_6_cast-time}}} {{components=@{repeating_lvl-2-spells_6_components}}} {{range=@{repeating_lvl-2-spells_6_range}}} {{target=@{repeating_lvl-2-spells_6_targets}}} {{duration=@{repeating_lvl-2-spells_6_duration}}} {{saving_throw=@{repeating_lvl-2-spells_6_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_6_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_6_sr}}} {{spell_description=@{repeating_lvl-2-spells_6_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_7_Cast" title="%{selected|repeating_lvl-2-spells_7_Cast}" value="/em casts @{repeating_lvl-2-spells_7_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_7_name}}} {{school=@{repeating_lvl-2-spells_7_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_7_cast-time}}} {{components=@{repeating_lvl-2-spells_7_components}}} {{range=@{repeating_lvl-2-spells_7_range}}} {{target=@{repeating_lvl-2-spells_7_targets}}} {{duration=@{repeating_lvl-2-spells_7_duration}}} {{saving_throw=@{repeating_lvl-2-spells_7_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_7_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_7_sr}}} {{spell_description=@{repeating_lvl-2-spells_7_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_8_Cast" title="%{selected|repeating_lvl-2-spells_8_Cast}" value="/em casts @{repeating_lvl-2-spells_8_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_8_name}}} {{school=@{repeating_lvl-2-spells_8_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_8_cast-time}}} {{components=@{repeating_lvl-2-spells_8_components}}} {{range=@{repeating_lvl-2-spells_8_range}}} {{target=@{repeating_lvl-2-spells_8_targets}}} {{duration=@{repeating_lvl-2-spells_8_duration}}} {{saving_throw=@{repeating_lvl-2-spells_8_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_8_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_8_sr}}} {{spell_description=@{repeating_lvl-2-spells_8_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_9_Cast" title="%{selected|repeating_lvl-2-spells_9_Cast}" value="/em casts @{repeating_lvl-2-spells_9_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_9_name}}} {{school=@{repeating_lvl-2-spells_9_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_9_cast-time}}} {{components=@{repeating_lvl-2-spells_9_components}}} {{range=@{repeating_lvl-2-spells_9_range}}} {{target=@{repeating_lvl-2-spells_9_targets}}} {{duration=@{repeating_lvl-2-spells_9_duration}}} {{saving_throw=@{repeating_lvl-2-spells_9_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_9_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_9_sr}}} {{spell_description=@{repeating_lvl-2-spells_9_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_10_Cast" title="%{selected|repeating_lvl-2-spells_10_Cast}" value="/em casts @{repeating_lvl-2-spells_10_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_10_name}}} {{school=@{repeating_lvl-2-spells_10_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_10_cast-time}}} {{components=@{repeating_lvl-2-spells_10_components}}} {{range=@{repeating_lvl-2-spells_10_range}}} {{target=@{repeating_lvl-2-spells_10_targets}}} {{duration=@{repeating_lvl-2-spells_10_duration}}} {{saving_throw=@{repeating_lvl-2-spells_10_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_10_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_10_sr}}} {{spell_description=@{repeating_lvl-2-spells_10_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_11_Cast" title="%{selected|repeating_lvl-2-spells_11_Cast}" value="/em casts @{repeating_lvl-2-spells_11_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_11_name}}} {{school=@{repeating_lvl-2-spells_11_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_11_cast-time}}} {{components=@{repeating_lvl-2-spells_11_components}}} {{range=@{repeating_lvl-2-spells_11_range}}} {{target=@{repeating_lvl-2-spells_11_targets}}} {{duration=@{repeating_lvl-2-spells_11_duration}}} {{saving_throw=@{repeating_lvl-2-spells_11_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_11_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_11_sr}}} {{spell_description=@{repeating_lvl-2-spells_11_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_12_Cast" title="%{selected|repeating_lvl-2-spells_12_Cast}" value="/em casts @{repeating_lvl-2-spells_12_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_12_name}}} {{school=@{repeating_lvl-2-spells_12_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_12_cast-time}}} {{components=@{repeating_lvl-2-spells_12_components}}} {{range=@{repeating_lvl-2-spells_12_range}}} {{target=@{repeating_lvl-2-spells_12_targets}}} {{duration=@{repeating_lvl-2-spells_12_duration}}} {{saving_throw=@{repeating_lvl-2-spells_12_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_12_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_12_sr}}} {{spell_description=@{repeating_lvl-2-spells_12_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_13_Cast" title="%{selected|repeating_lvl-2-spells_13_Cast}" value="/em casts @{repeating_lvl-2-spells_13_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_13_name}}} {{school=@{repeating_lvl-2-spells_13_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_13_cast-time}}} {{components=@{repeating_lvl-2-spells_13_components}}} {{range=@{repeating_lvl-2-spells_13_range}}} {{target=@{repeating_lvl-2-spells_13_targets}}} {{duration=@{repeating_lvl-2-spells_13_duration}}} {{saving_throw=@{repeating_lvl-2-spells_13_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_13_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_13_sr}}} {{spell_description=@{repeating_lvl-2-spells_13_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_14_Cast" title="%{selected|repeating_lvl-2-spells_14_Cast}" value="/em casts @{repeating_lvl-2-spells_14_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_14_name}}} {{school=@{repeating_lvl-2-spells_14_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_14_cast-time}}} {{components=@{repeating_lvl-2-spells_14_components}}} {{range=@{repeating_lvl-2-spells_14_range}}} {{target=@{repeating_lvl-2-spells_14_targets}}} {{duration=@{repeating_lvl-2-spells_14_duration}}} {{saving_throw=@{repeating_lvl-2-spells_14_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_14_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_14_sr}}} {{spell_description=@{repeating_lvl-2-spells_14_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_15_Cast" title="%{selected|repeating_lvl-2-spells_15_Cast}" value="/em casts @{repeating_lvl-2-spells_15_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_15_name}}} {{school=@{repeating_lvl-2-spells_15_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_15_cast-time}}} {{components=@{repeating_lvl-2-spells_15_components}}} {{range=@{repeating_lvl-2-spells_15_range}}} {{target=@{repeating_lvl-2-spells_15_targets}}} {{duration=@{repeating_lvl-2-spells_15_duration}}} {{saving_throw=@{repeating_lvl-2-spells_15_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_15_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_15_sr}}} {{spell_description=@{repeating_lvl-2-spells_15_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_16_Cast" title="%{selected|repeating_lvl-2-spells_16_Cast}" value="/em casts @{repeating_lvl-2-spells_16_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_16_name}}} {{school=@{repeating_lvl-2-spells_16_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_16_cast-time}}} {{components=@{repeating_lvl-2-spells_16_components}}} {{range=@{repeating_lvl-2-spells_16_range}}} {{target=@{repeating_lvl-2-spells_16_targets}}} {{duration=@{repeating_lvl-2-spells_16_duration}}} {{saving_throw=@{repeating_lvl-2-spells_16_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_16_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_16_sr}}} {{spell_description=@{repeating_lvl-2-spells_16_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_17_Cast" title="%{selected|repeating_lvl-2-spells_17_Cast}" value="/em casts @{repeating_lvl-2-spells_17_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_17_name}}} {{school=@{repeating_lvl-2-spells_17_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_17_cast-time}}} {{components=@{repeating_lvl-2-spells_17_components}}} {{range=@{repeating_lvl-2-spells_17_range}}} {{target=@{repeating_lvl-2-spells_17_targets}}} {{duration=@{repeating_lvl-2-spells_17_duration}}} {{saving_throw=@{repeating_lvl-2-spells_17_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_17_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_17_sr}}} {{spell_description=@{repeating_lvl-2-spells_17_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_18_Cast" title="%{selected|repeating_lvl-2-spells_18_Cast}" value="/em casts @{repeating_lvl-2-spells_18_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_18_name}}} {{school=@{repeating_lvl-2-spells_18_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_18_cast-time}}} {{components=@{repeating_lvl-2-spells_18_components}}} {{range=@{repeating_lvl-2-spells_18_range}}} {{target=@{repeating_lvl-2-spells_18_targets}}} {{duration=@{repeating_lvl-2-spells_18_duration}}} {{saving_throw=@{repeating_lvl-2-spells_18_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_18_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_18_sr}}} {{spell_description=@{repeating_lvl-2-spells_18_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_19_Cast" title="%{selected|repeating_lvl-2-spells_19_Cast}" value="/em casts @{repeating_lvl-2-spells_19_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_19_name}}} {{school=@{repeating_lvl-2-spells_19_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_19_cast-time}}} {{components=@{repeating_lvl-2-spells_19_components}}} {{range=@{repeating_lvl-2-spells_19_range}}} {{target=@{repeating_lvl-2-spells_19_targets}}} {{duration=@{repeating_lvl-2-spells_19_duration}}} {{saving_throw=@{repeating_lvl-2-spells_19_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_19_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_19_sr}}} {{spell_description=@{repeating_lvl-2-spells_19_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_20_Cast" title="%{selected|repeating_lvl-2-spells_20_Cast}" value="/em casts @{repeating_lvl-2-spells_20_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_20_name}}} {{school=@{repeating_lvl-2-spells_20_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_20_cast-time}}} {{components=@{repeating_lvl-2-spells_20_components}}} {{range=@{repeating_lvl-2-spells_20_range}}} {{target=@{repeating_lvl-2-spells_20_targets}}} {{duration=@{repeating_lvl-2-spells_20_duration}}} {{saving_throw=@{repeating_lvl-2-spells_20_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_20_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_20_sr}}} {{spell_description=@{repeating_lvl-2-spells_20_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_21_Cast" title="%{selected|repeating_lvl-2-spells_21_Cast}" value="/em casts @{repeating_lvl-2-spells_21_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_21_name}}} {{school=@{repeating_lvl-2-spells_21_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_21_cast-time}}} {{components=@{repeating_lvl-2-spells_21_components}}} {{range=@{repeating_lvl-2-spells_21_range}}} {{target=@{repeating_lvl-2-spells_21_targets}}} {{duration=@{repeating_lvl-2-spells_21_duration}}} {{saving_throw=@{repeating_lvl-2-spells_21_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_21_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_21_sr}}} {{spell_description=@{repeating_lvl-2-spells_21_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_22_Cast" title="%{selected|repeating_lvl-2-spells_22_Cast}" value="/em casts @{repeating_lvl-2-spells_22_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_22_name}}} {{school=@{repeating_lvl-2-spells_22_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_22_cast-time}}} {{components=@{repeating_lvl-2-spells_22_components}}} {{range=@{repeating_lvl-2-spells_22_range}}} {{target=@{repeating_lvl-2-spells_22_targets}}} {{duration=@{repeating_lvl-2-spells_22_duration}}} {{saving_throw=@{repeating_lvl-2-spells_22_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_22_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_22_sr}}} {{spell_description=@{repeating_lvl-2-spells_22_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_23_Cast" title="%{selected|repeating_lvl-2-spells_23_Cast}" value="/em casts @{repeating_lvl-2-spells_23_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_23_name}}} {{school=@{repeating_lvl-2-spells_23_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_23_cast-time}}} {{components=@{repeating_lvl-2-spells_23_components}}} {{range=@{repeating_lvl-2-spells_23_range}}} {{target=@{repeating_lvl-2-spells_23_targets}}} {{duration=@{repeating_lvl-2-spells_23_duration}}} {{saving_throw=@{repeating_lvl-2-spells_23_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_23_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_23_sr}}} {{spell_description=@{repeating_lvl-2-spells_23_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_24_Cast" title="%{selected|repeating_lvl-2-spells_24_Cast}" value="/em casts @{repeating_lvl-2-spells_24_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_24_name}}} {{school=@{repeating_lvl-2-spells_24_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_24_cast-time}}} {{components=@{repeating_lvl-2-spells_24_components}}} {{range=@{repeating_lvl-2-spells_24_range}}} {{target=@{repeating_lvl-2-spells_24_targets}}} {{duration=@{repeating_lvl-2-spells_24_duration}}} {{saving_throw=@{repeating_lvl-2-spells_24_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_24_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_24_sr}}} {{spell_description=@{repeating_lvl-2-spells_24_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_25_Cast" title="%{selected|repeating_lvl-2-spells_25_Cast}" value="/em casts @{repeating_lvl-2-spells_25_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_25_name}}} {{school=@{repeating_lvl-2-spells_25_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_25_cast-time}}} {{components=@{repeating_lvl-2-spells_25_components}}} {{range=@{repeating_lvl-2-spells_25_range}}} {{target=@{repeating_lvl-2-spells_25_targets}}} {{duration=@{repeating_lvl-2-spells_25_duration}}} {{saving_throw=@{repeating_lvl-2-spells_25_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_25_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_25_sr}}} {{spell_description=@{repeating_lvl-2-spells_25_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-2-spells_26_Cast" title="%{selected|repeating_lvl-2-spells_26_Cast}" value="/em casts @{repeating_lvl-2-spells_26_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-2-spells_26_name}}} {{school=@{repeating_lvl-2-spells_26_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-2-spells_26_cast-time}}} {{components=@{repeating_lvl-2-spells_26_components}}} {{range=@{repeating_lvl-2-spells_26_range}}} {{target=@{repeating_lvl-2-spells_26_targets}}} {{duration=@{repeating_lvl-2-spells_26_duration}}} {{saving_throw=@{repeating_lvl-2-spells_26_save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{repeating_lvl-2-spells_26_DC-mod}]]}} {{sr=@{repeating_lvl-2-spells_26_sr}}} {{spell_description=@{repeating_lvl-2-spells_26_description}}}"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-sect">
+			<div class="sheet-table">
+				<span class="sheet-table-name">Level 2 Spells</span>
+			</div>
+			<fieldset class="repeating_lvl-2-spells">
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
+                </div>
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>					
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_duration}" type="text" value="N/A" name="attr_duration" placeholder="Duration"><br>Duration</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
+					<span class="sheet-table-data sheet-center sheet-small-label">
+						<select title="@{repeating_lvl-2-spells_X_sr}" name="attr_sr">
+							<option value="" selected>Select SR</option>
+							<option value="Yes">Yes</option>
+							<option value="No">No</option>
+						</select>
+						<br>SR
+					</span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-2-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_lvl-2-spells_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-2-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-2-spells_X_macro-text}" name="attr_macro-text">/em casts @{name}!&#x00A;&{template:pf_spell} {{name=@{name}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[@{spellclass-0-level-2-savedc} + @{DC-mod}]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+	<div>
+		<b>Level 3 Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{lvl-3-spells-show}" name="attr_lvl-3-spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Level 3 Spell Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_0_Cast" title="%{selected|repeating_lvl-3-spells_0_Cast}" value="/em casts @{repeating_lvl-3-spells_0_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_0_name}}} {{school=@{repeating_lvl-3-spells_0_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_0_cast-time}}} {{components=@{repeating_lvl-3-spells_0_components}}} {{range=@{repeating_lvl-3-spells_0_range}}} {{target=@{repeating_lvl-3-spells_0_targets}}} {{duration=@{repeating_lvl-3-spells_0_duration}}} {{saving_throw=@{repeating_lvl-3-spells_0_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_0_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_0_sr}}} {{spell_description=@{repeating_lvl-3-spells_0_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_1_Cast" title="%{selected|repeating_lvl-3-spells_1_Cast}" value="/em casts @{repeating_lvl-3-spells_1_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_1_name}}} {{school=@{repeating_lvl-3-spells_1_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_1_cast-time}}} {{components=@{repeating_lvl-3-spells_1_components}}} {{range=@{repeating_lvl-3-spells_1_range}}} {{target=@{repeating_lvl-3-spells_1_targets}}} {{duration=@{repeating_lvl-3-spells_1_duration}}} {{saving_throw=@{repeating_lvl-3-spells_1_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_1_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_1_sr}}} {{spell_description=@{repeating_lvl-3-spells_1_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_2_Cast" title="%{selected|repeating_lvl-3-spells_2_Cast}" value="/em casts @{repeating_lvl-3-spells_2_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_2_name}}} {{school=@{repeating_lvl-3-spells_2_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_2_cast-time}}} {{components=@{repeating_lvl-3-spells_2_components}}} {{range=@{repeating_lvl-3-spells_2_range}}} {{target=@{repeating_lvl-3-spells_2_targets}}} {{duration=@{repeating_lvl-3-spells_2_duration}}} {{saving_throw=@{repeating_lvl-3-spells_2_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_2_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_2_sr}}} {{spell_description=@{repeating_lvl-3-spells_2_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_3_Cast" title="%{selected|repeating_lvl-3-spells_3_Cast}" value="/em casts @{repeating_lvl-3-spells_3_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_3_name}}} {{school=@{repeating_lvl-3-spells_3_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_3_cast-time}}} {{components=@{repeating_lvl-3-spells_3_components}}} {{range=@{repeating_lvl-3-spells_3_range}}} {{target=@{repeating_lvl-3-spells_3_targets}}} {{duration=@{repeating_lvl-3-spells_3_duration}}} {{saving_throw=@{repeating_lvl-3-spells_3_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_3_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_3_sr}}} {{spell_description=@{repeating_lvl-3-spells_3_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_4_Cast" title="%{selected|repeating_lvl-3-spells_4_Cast}" value="/em casts @{repeating_lvl-3-spells_4_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_4_name}}} {{school=@{repeating_lvl-3-spells_4_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_4_cast-time}}} {{components=@{repeating_lvl-3-spells_4_components}}} {{range=@{repeating_lvl-3-spells_4_range}}} {{target=@{repeating_lvl-3-spells_4_targets}}} {{duration=@{repeating_lvl-3-spells_4_duration}}} {{saving_throw=@{repeating_lvl-3-spells_4_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_4_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_4_sr}}} {{spell_description=@{repeating_lvl-3-spells_4_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_5_Cast" title="%{selected|repeating_lvl-3-spells_5_Cast}" value="/em casts @{repeating_lvl-3-spells_5_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_5_name}}} {{school=@{repeating_lvl-3-spells_5_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_5_cast-time}}} {{components=@{repeating_lvl-3-spells_5_components}}} {{range=@{repeating_lvl-3-spells_5_range}}} {{target=@{repeating_lvl-3-spells_5_targets}}} {{duration=@{repeating_lvl-3-spells_5_duration}}} {{saving_throw=@{repeating_lvl-3-spells_5_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_5_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_5_sr}}} {{spell_description=@{repeating_lvl-3-spells_5_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_6_Cast" title="%{selected|repeating_lvl-3-spells_6_Cast}" value="/em casts @{repeating_lvl-3-spells_6_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_6_name}}} {{school=@{repeating_lvl-3-spells_6_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_6_cast-time}}} {{components=@{repeating_lvl-3-spells_6_components}}} {{range=@{repeating_lvl-3-spells_6_range}}} {{target=@{repeating_lvl-3-spells_6_targets}}} {{duration=@{repeating_lvl-3-spells_6_duration}}} {{saving_throw=@{repeating_lvl-3-spells_6_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_6_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_6_sr}}} {{spell_description=@{repeating_lvl-3-spells_6_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_7_Cast" title="%{selected|repeating_lvl-3-spells_7_Cast}" value="/em casts @{repeating_lvl-3-spells_7_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_7_name}}} {{school=@{repeating_lvl-3-spells_7_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_7_cast-time}}} {{components=@{repeating_lvl-3-spells_7_components}}} {{range=@{repeating_lvl-3-spells_7_range}}} {{target=@{repeating_lvl-3-spells_7_targets}}} {{duration=@{repeating_lvl-3-spells_7_duration}}} {{saving_throw=@{repeating_lvl-3-spells_7_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_7_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_7_sr}}} {{spell_description=@{repeating_lvl-3-spells_7_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_8_Cast" title="%{selected|repeating_lvl-3-spells_8_Cast}" value="/em casts @{repeating_lvl-3-spells_8_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_8_name}}} {{school=@{repeating_lvl-3-spells_8_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_8_cast-time}}} {{components=@{repeating_lvl-3-spells_8_components}}} {{range=@{repeating_lvl-3-spells_8_range}}} {{target=@{repeating_lvl-3-spells_8_targets}}} {{duration=@{repeating_lvl-3-spells_8_duration}}} {{saving_throw=@{repeating_lvl-3-spells_8_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_8_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_8_sr}}} {{spell_description=@{repeating_lvl-3-spells_8_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_9_Cast" title="%{selected|repeating_lvl-3-spells_9_Cast}" value="/em casts @{repeating_lvl-3-spells_9_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_9_name}}} {{school=@{repeating_lvl-3-spells_9_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_9_cast-time}}} {{components=@{repeating_lvl-3-spells_9_components}}} {{range=@{repeating_lvl-3-spells_9_range}}} {{target=@{repeating_lvl-3-spells_9_targets}}} {{duration=@{repeating_lvl-3-spells_9_duration}}} {{saving_throw=@{repeating_lvl-3-spells_9_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_9_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_9_sr}}} {{spell_description=@{repeating_lvl-3-spells_9_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_10_Cast" title="%{selected|repeating_lvl-3-spells_10_Cast}" value="/em casts @{repeating_lvl-3-spells_10_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_10_name}}} {{school=@{repeating_lvl-3-spells_10_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_10_cast-time}}} {{components=@{repeating_lvl-3-spells_10_components}}} {{range=@{repeating_lvl-3-spells_10_range}}} {{target=@{repeating_lvl-3-spells_10_targets}}} {{duration=@{repeating_lvl-3-spells_10_duration}}} {{saving_throw=@{repeating_lvl-3-spells_10_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_10_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_10_sr}}} {{spell_description=@{repeating_lvl-3-spells_10_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_11_Cast" title="%{selected|repeating_lvl-3-spells_11_Cast}" value="/em casts @{repeating_lvl-3-spells_11_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_11_name}}} {{school=@{repeating_lvl-3-spells_11_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_11_cast-time}}} {{components=@{repeating_lvl-3-spells_11_components}}} {{range=@{repeating_lvl-3-spells_11_range}}} {{target=@{repeating_lvl-3-spells_11_targets}}} {{duration=@{repeating_lvl-3-spells_11_duration}}} {{saving_throw=@{repeating_lvl-3-spells_11_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_11_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_11_sr}}} {{spell_description=@{repeating_lvl-3-spells_11_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_12_Cast" title="%{selected|repeating_lvl-3-spells_12_Cast}" value="/em casts @{repeating_lvl-3-spells_12_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_12_name}}} {{school=@{repeating_lvl-3-spells_12_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_12_cast-time}}} {{components=@{repeating_lvl-3-spells_12_components}}} {{range=@{repeating_lvl-3-spells_12_range}}} {{target=@{repeating_lvl-3-spells_12_targets}}} {{duration=@{repeating_lvl-3-spells_12_duration}}} {{saving_throw=@{repeating_lvl-3-spells_12_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_12_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_12_sr}}} {{spell_description=@{repeating_lvl-3-spells_12_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_13_Cast" title="%{selected|repeating_lvl-3-spells_13_Cast}" value="/em casts @{repeating_lvl-3-spells_13_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_13_name}}} {{school=@{repeating_lvl-3-spells_13_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_13_cast-time}}} {{components=@{repeating_lvl-3-spells_13_components}}} {{range=@{repeating_lvl-3-spells_13_range}}} {{target=@{repeating_lvl-3-spells_13_targets}}} {{duration=@{repeating_lvl-3-spells_13_duration}}} {{saving_throw=@{repeating_lvl-3-spells_13_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_13_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_13_sr}}} {{spell_description=@{repeating_lvl-3-spells_13_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_14_Cast" title="%{selected|repeating_lvl-3-spells_14_Cast}" value="/em casts @{repeating_lvl-3-spells_14_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_14_name}}} {{school=@{repeating_lvl-3-spells_14_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_14_cast-time}}} {{components=@{repeating_lvl-3-spells_14_components}}} {{range=@{repeating_lvl-3-spells_14_range}}} {{target=@{repeating_lvl-3-spells_14_targets}}} {{duration=@{repeating_lvl-3-spells_14_duration}}} {{saving_throw=@{repeating_lvl-3-spells_14_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_14_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_14_sr}}} {{spell_description=@{repeating_lvl-3-spells_14_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_15_Cast" title="%{selected|repeating_lvl-3-spells_15_Cast}" value="/em casts @{repeating_lvl-3-spells_15_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_15_name}}} {{school=@{repeating_lvl-3-spells_15_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_15_cast-time}}} {{components=@{repeating_lvl-3-spells_15_components}}} {{range=@{repeating_lvl-3-spells_15_range}}} {{target=@{repeating_lvl-3-spells_15_targets}}} {{duration=@{repeating_lvl-3-spells_15_duration}}} {{saving_throw=@{repeating_lvl-3-spells_15_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_15_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_15_sr}}} {{spell_description=@{repeating_lvl-3-spells_15_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_16_Cast" title="%{selected|repeating_lvl-3-spells_16_Cast}" value="/em casts @{repeating_lvl-3-spells_16_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_16_name}}} {{school=@{repeating_lvl-3-spells_16_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_16_cast-time}}} {{components=@{repeating_lvl-3-spells_16_components}}} {{range=@{repeating_lvl-3-spells_16_range}}} {{target=@{repeating_lvl-3-spells_16_targets}}} {{duration=@{repeating_lvl-3-spells_16_duration}}} {{saving_throw=@{repeating_lvl-3-spells_16_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_16_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_16_sr}}} {{spell_description=@{repeating_lvl-3-spells_16_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_17_Cast" title="%{selected|repeating_lvl-3-spells_17_Cast}" value="/em casts @{repeating_lvl-3-spells_17_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_17_name}}} {{school=@{repeating_lvl-3-spells_17_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_17_cast-time}}} {{components=@{repeating_lvl-3-spells_17_components}}} {{range=@{repeating_lvl-3-spells_17_range}}} {{target=@{repeating_lvl-3-spells_17_targets}}} {{duration=@{repeating_lvl-3-spells_17_duration}}} {{saving_throw=@{repeating_lvl-3-spells_17_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_17_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_17_sr}}} {{spell_description=@{repeating_lvl-3-spells_17_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_18_Cast" title="%{selected|repeating_lvl-3-spells_18_Cast}" value="/em casts @{repeating_lvl-3-spells_18_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_18_name}}} {{school=@{repeating_lvl-3-spells_18_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_18_cast-time}}} {{components=@{repeating_lvl-3-spells_18_components}}} {{range=@{repeating_lvl-3-spells_18_range}}} {{target=@{repeating_lvl-3-spells_18_targets}}} {{duration=@{repeating_lvl-3-spells_18_duration}}} {{saving_throw=@{repeating_lvl-3-spells_18_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_18_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_18_sr}}} {{spell_description=@{repeating_lvl-3-spells_18_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_19_Cast" title="%{selected|repeating_lvl-3-spells_19_Cast}" value="/em casts @{repeating_lvl-3-spells_19_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_19_name}}} {{school=@{repeating_lvl-3-spells_19_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_19_cast-time}}} {{components=@{repeating_lvl-3-spells_19_components}}} {{range=@{repeating_lvl-3-spells_19_range}}} {{target=@{repeating_lvl-3-spells_19_targets}}} {{duration=@{repeating_lvl-3-spells_19_duration}}} {{saving_throw=@{repeating_lvl-3-spells_19_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_19_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_19_sr}}} {{spell_description=@{repeating_lvl-3-spells_19_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_20_Cast" title="%{selected|repeating_lvl-3-spells_20_Cast}" value="/em casts @{repeating_lvl-3-spells_20_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_20_name}}} {{school=@{repeating_lvl-3-spells_20_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_20_cast-time}}} {{components=@{repeating_lvl-3-spells_20_components}}} {{range=@{repeating_lvl-3-spells_20_range}}} {{target=@{repeating_lvl-3-spells_20_targets}}} {{duration=@{repeating_lvl-3-spells_20_duration}}} {{saving_throw=@{repeating_lvl-3-spells_20_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_20_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_20_sr}}} {{spell_description=@{repeating_lvl-3-spells_20_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_21_Cast" title="%{selected|repeating_lvl-3-spells_21_Cast}" value="/em casts @{repeating_lvl-3-spells_21_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_21_name}}} {{school=@{repeating_lvl-3-spells_21_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_21_cast-time}}} {{components=@{repeating_lvl-3-spells_21_components}}} {{range=@{repeating_lvl-3-spells_21_range}}} {{target=@{repeating_lvl-3-spells_21_targets}}} {{duration=@{repeating_lvl-3-spells_21_duration}}} {{saving_throw=@{repeating_lvl-3-spells_21_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_21_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_21_sr}}} {{spell_description=@{repeating_lvl-3-spells_21_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_22_Cast" title="%{selected|repeating_lvl-3-spells_22_Cast}" value="/em casts @{repeating_lvl-3-spells_22_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_22_name}}} {{school=@{repeating_lvl-3-spells_22_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_22_cast-time}}} {{components=@{repeating_lvl-3-spells_22_components}}} {{range=@{repeating_lvl-3-spells_22_range}}} {{target=@{repeating_lvl-3-spells_22_targets}}} {{duration=@{repeating_lvl-3-spells_22_duration}}} {{saving_throw=@{repeating_lvl-3-spells_22_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_22_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_22_sr}}} {{spell_description=@{repeating_lvl-3-spells_22_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_23_Cast" title="%{selected|repeating_lvl-3-spells_23_Cast}" value="/em casts @{repeating_lvl-3-spells_23_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_23_name}}} {{school=@{repeating_lvl-3-spells_23_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_23_cast-time}}} {{components=@{repeating_lvl-3-spells_23_components}}} {{range=@{repeating_lvl-3-spells_23_range}}} {{target=@{repeating_lvl-3-spells_23_targets}}} {{duration=@{repeating_lvl-3-spells_23_duration}}} {{saving_throw=@{repeating_lvl-3-spells_23_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_23_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_23_sr}}} {{spell_description=@{repeating_lvl-3-spells_23_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_24_Cast" title="%{selected|repeating_lvl-3-spells_24_Cast}" value="/em casts @{repeating_lvl-3-spells_24_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_24_name}}} {{school=@{repeating_lvl-3-spells_24_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_24_cast-time}}} {{components=@{repeating_lvl-3-spells_24_components}}} {{range=@{repeating_lvl-3-spells_24_range}}} {{target=@{repeating_lvl-3-spells_24_targets}}} {{duration=@{repeating_lvl-3-spells_24_duration}}} {{saving_throw=@{repeating_lvl-3-spells_24_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_24_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_24_sr}}} {{spell_description=@{repeating_lvl-3-spells_24_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_25_Cast" title="%{selected|repeating_lvl-3-spells_25_Cast}" value="/em casts @{repeating_lvl-3-spells_25_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_25_name}}} {{school=@{repeating_lvl-3-spells_25_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_25_cast-time}}} {{components=@{repeating_lvl-3-spells_25_components}}} {{range=@{repeating_lvl-3-spells_25_range}}} {{target=@{repeating_lvl-3-spells_25_targets}}} {{duration=@{repeating_lvl-3-spells_25_duration}}} {{saving_throw=@{repeating_lvl-3-spells_25_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_25_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_25_sr}}} {{spell_description=@{repeating_lvl-3-spells_25_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-3-spells_26_Cast" title="%{selected|repeating_lvl-3-spells_26_Cast}" value="/em casts @{repeating_lvl-3-spells_26_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-3-spells_26_name}}} {{school=@{repeating_lvl-3-spells_26_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-3-spells_26_cast-time}}} {{components=@{repeating_lvl-3-spells_26_components}}} {{range=@{repeating_lvl-3-spells_26_range}}} {{target=@{repeating_lvl-3-spells_26_targets}}} {{duration=@{repeating_lvl-3-spells_26_duration}}} {{saving_throw=@{repeating_lvl-3-spells_26_save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{repeating_lvl-3-spells_26_DC-mod}]]}} {{sr=@{repeating_lvl-3-spells_26_sr}}} {{spell_description=@{repeating_lvl-3-spells_26_description}}}"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-sect">
+			<div class="sheet-table">
+				<span class="sheet-table-name">Level 3 Spells</span>
+			</div>
+			<fieldset class="repeating_lvl-3-spells">
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
+                </div>
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>					
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_duration}" type="text" value="N/A" name="attr_duration" placeholder="Duration"><br>Duration</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
+					<span class="sheet-table-data sheet-center sheet-small-label">
+						<select title="@{repeating_lvl-3-spells_X_sr}" name="attr_sr">
+							<option value="" selected>Select SR</option>
+							<option value="Yes">Yes</option>
+							<option value="No">No</option>
+						</select>
+						<br>SR
+					</span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-3-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_lvl-3-spells_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-3-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-3-spells_X_macro-text}" name="attr_macro-text">/em casts @{name}!&#x00A;&{template:pf_spell} {{name=@{name}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[@{spellclass-0-level-3-savedc} + @{DC-mod}]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
+				<hr>
+			</fieldset>
+		</div>      
+	</div>
+	<div>
+		<b>Level 4 Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{lvl-4-spells-show}" name="attr_lvl-4-spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Level 4 Spell Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_0_Cast" title="%{selected|repeating_lvl-4-spells_0_Cast}" value="/em casts @{repeating_lvl-4-spells_0_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_0_name}}} {{school=@{repeating_lvl-4-spells_0_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_0_cast-time}}} {{components=@{repeating_lvl-4-spells_0_components}}} {{range=@{repeating_lvl-4-spells_0_range}}} {{target=@{repeating_lvl-4-spells_0_targets}}} {{duration=@{repeating_lvl-4-spells_0_duration}}} {{saving_throw=@{repeating_lvl-4-spells_0_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_0_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_0_sr}}} {{spell_description=@{repeating_lvl-4-spells_0_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_1_Cast" title="%{selected|repeating_lvl-4-spells_1_Cast}" value="/em casts @{repeating_lvl-4-spells_1_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_1_name}}} {{school=@{repeating_lvl-4-spells_1_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_1_cast-time}}} {{components=@{repeating_lvl-4-spells_1_components}}} {{range=@{repeating_lvl-4-spells_1_range}}} {{target=@{repeating_lvl-4-spells_1_targets}}} {{duration=@{repeating_lvl-4-spells_1_duration}}} {{saving_throw=@{repeating_lvl-4-spells_1_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_1_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_1_sr}}} {{spell_description=@{repeating_lvl-4-spells_1_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_2_Cast" title="%{selected|repeating_lvl-4-spells_2_Cast}" value="/em casts @{repeating_lvl-4-spells_2_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_2_name}}} {{school=@{repeating_lvl-4-spells_2_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_2_cast-time}}} {{components=@{repeating_lvl-4-spells_2_components}}} {{range=@{repeating_lvl-4-spells_2_range}}} {{target=@{repeating_lvl-4-spells_2_targets}}} {{duration=@{repeating_lvl-4-spells_2_duration}}} {{saving_throw=@{repeating_lvl-4-spells_2_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_2_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_2_sr}}} {{spell_description=@{repeating_lvl-4-spells_2_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_3_Cast" title="%{selected|repeating_lvl-4-spells_3_Cast}" value="/em casts @{repeating_lvl-4-spells_3_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_3_name}}} {{school=@{repeating_lvl-4-spells_3_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_3_cast-time}}} {{components=@{repeating_lvl-4-spells_3_components}}} {{range=@{repeating_lvl-4-spells_3_range}}} {{target=@{repeating_lvl-4-spells_3_targets}}} {{duration=@{repeating_lvl-4-spells_3_duration}}} {{saving_throw=@{repeating_lvl-4-spells_3_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_3_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_3_sr}}} {{spell_description=@{repeating_lvl-4-spells_3_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_4_Cast" title="%{selected|repeating_lvl-4-spells_4_Cast}" value="/em casts @{repeating_lvl-4-spells_4_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_4_name}}} {{school=@{repeating_lvl-4-spells_4_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_4_cast-time}}} {{components=@{repeating_lvl-4-spells_4_components}}} {{range=@{repeating_lvl-4-spells_4_range}}} {{target=@{repeating_lvl-4-spells_4_targets}}} {{duration=@{repeating_lvl-4-spells_4_duration}}} {{saving_throw=@{repeating_lvl-4-spells_4_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_4_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_4_sr}}} {{spell_description=@{repeating_lvl-4-spells_4_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_5_Cast" title="%{selected|repeating_lvl-4-spells_5_Cast}" value="/em casts @{repeating_lvl-4-spells_5_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_5_name}}} {{school=@{repeating_lvl-4-spells_5_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_5_cast-time}}} {{components=@{repeating_lvl-4-spells_5_components}}} {{range=@{repeating_lvl-4-spells_5_range}}} {{target=@{repeating_lvl-4-spells_5_targets}}} {{duration=@{repeating_lvl-4-spells_5_duration}}} {{saving_throw=@{repeating_lvl-4-spells_5_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_5_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_5_sr}}} {{spell_description=@{repeating_lvl-4-spells_5_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_6_Cast" title="%{selected|repeating_lvl-4-spells_6_Cast}" value="/em casts @{repeating_lvl-4-spells_6_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_6_name}}} {{school=@{repeating_lvl-4-spells_6_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_6_cast-time}}} {{components=@{repeating_lvl-4-spells_6_components}}} {{range=@{repeating_lvl-4-spells_6_range}}} {{target=@{repeating_lvl-4-spells_6_targets}}} {{duration=@{repeating_lvl-4-spells_6_duration}}} {{saving_throw=@{repeating_lvl-4-spells_6_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_6_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_6_sr}}} {{spell_description=@{repeating_lvl-4-spells_6_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_7_Cast" title="%{selected|repeating_lvl-4-spells_7_Cast}" value="/em casts @{repeating_lvl-4-spells_7_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_7_name}}} {{school=@{repeating_lvl-4-spells_7_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_7_cast-time}}} {{components=@{repeating_lvl-4-spells_7_components}}} {{range=@{repeating_lvl-4-spells_7_range}}} {{target=@{repeating_lvl-4-spells_7_targets}}} {{duration=@{repeating_lvl-4-spells_7_duration}}} {{saving_throw=@{repeating_lvl-4-spells_7_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_7_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_7_sr}}} {{spell_description=@{repeating_lvl-4-spells_7_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_8_Cast" title="%{selected|repeating_lvl-4-spells_8_Cast}" value="/em casts @{repeating_lvl-4-spells_8_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_8_name}}} {{school=@{repeating_lvl-4-spells_8_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_8_cast-time}}} {{components=@{repeating_lvl-4-spells_8_components}}} {{range=@{repeating_lvl-4-spells_8_range}}} {{target=@{repeating_lvl-4-spells_8_targets}}} {{duration=@{repeating_lvl-4-spells_8_duration}}} {{saving_throw=@{repeating_lvl-4-spells_8_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_8_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_8_sr}}} {{spell_description=@{repeating_lvl-4-spells_8_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_9_Cast" title="%{selected|repeating_lvl-4-spells_9_Cast}" value="/em casts @{repeating_lvl-4-spells_9_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_9_name}}} {{school=@{repeating_lvl-4-spells_9_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_9_cast-time}}} {{components=@{repeating_lvl-4-spells_9_components}}} {{range=@{repeating_lvl-4-spells_9_range}}} {{target=@{repeating_lvl-4-spells_9_targets}}} {{duration=@{repeating_lvl-4-spells_9_duration}}} {{saving_throw=@{repeating_lvl-4-spells_9_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_9_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_9_sr}}} {{spell_description=@{repeating_lvl-4-spells_9_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_10_Cast" title="%{selected|repeating_lvl-4-spells_10_Cast}" value="/em casts @{repeating_lvl-4-spells_10_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_10_name}}} {{school=@{repeating_lvl-4-spells_10_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_10_cast-time}}} {{components=@{repeating_lvl-4-spells_10_components}}} {{range=@{repeating_lvl-4-spells_10_range}}} {{target=@{repeating_lvl-4-spells_10_targets}}} {{duration=@{repeating_lvl-4-spells_10_duration}}} {{saving_throw=@{repeating_lvl-4-spells_10_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_10_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_10_sr}}} {{spell_description=@{repeating_lvl-4-spells_10_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_11_Cast" title="%{selected|repeating_lvl-4-spells_11_Cast}" value="/em casts @{repeating_lvl-4-spells_11_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_11_name}}} {{school=@{repeating_lvl-4-spells_11_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_11_cast-time}}} {{components=@{repeating_lvl-4-spells_11_components}}} {{range=@{repeating_lvl-4-spells_11_range}}} {{target=@{repeating_lvl-4-spells_11_targets}}} {{duration=@{repeating_lvl-4-spells_11_duration}}} {{saving_throw=@{repeating_lvl-4-spells_11_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_11_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_11_sr}}} {{spell_description=@{repeating_lvl-4-spells_11_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_12_Cast" title="%{selected|repeating_lvl-4-spells_12_Cast}" value="/em casts @{repeating_lvl-4-spells_12_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_12_name}}} {{school=@{repeating_lvl-4-spells_12_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_12_cast-time}}} {{components=@{repeating_lvl-4-spells_12_components}}} {{range=@{repeating_lvl-4-spells_12_range}}} {{target=@{repeating_lvl-4-spells_12_targets}}} {{duration=@{repeating_lvl-4-spells_12_duration}}} {{saving_throw=@{repeating_lvl-4-spells_12_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_12_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_12_sr}}} {{spell_description=@{repeating_lvl-4-spells_12_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_13_Cast" title="%{selected|repeating_lvl-4-spells_13_Cast}" value="/em casts @{repeating_lvl-4-spells_13_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_13_name}}} {{school=@{repeating_lvl-4-spells_13_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_13_cast-time}}} {{components=@{repeating_lvl-4-spells_13_components}}} {{range=@{repeating_lvl-4-spells_13_range}}} {{target=@{repeating_lvl-4-spells_13_targets}}} {{duration=@{repeating_lvl-4-spells_13_duration}}} {{saving_throw=@{repeating_lvl-4-spells_13_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_13_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_13_sr}}} {{spell_description=@{repeating_lvl-4-spells_13_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_14_Cast" title="%{selected|repeating_lvl-4-spells_14_Cast}" value="/em casts @{repeating_lvl-4-spells_14_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_14_name}}} {{school=@{repeating_lvl-4-spells_14_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_14_cast-time}}} {{components=@{repeating_lvl-4-spells_14_components}}} {{range=@{repeating_lvl-4-spells_14_range}}} {{target=@{repeating_lvl-4-spells_14_targets}}} {{duration=@{repeating_lvl-4-spells_14_duration}}} {{saving_throw=@{repeating_lvl-4-spells_14_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_14_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_14_sr}}} {{spell_description=@{repeating_lvl-4-spells_14_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_15_Cast" title="%{selected|repeating_lvl-4-spells_15_Cast}" value="/em casts @{repeating_lvl-4-spells_15_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_15_name}}} {{school=@{repeating_lvl-4-spells_15_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_15_cast-time}}} {{components=@{repeating_lvl-4-spells_15_components}}} {{range=@{repeating_lvl-4-spells_15_range}}} {{target=@{repeating_lvl-4-spells_15_targets}}} {{duration=@{repeating_lvl-4-spells_15_duration}}} {{saving_throw=@{repeating_lvl-4-spells_15_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_15_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_15_sr}}} {{spell_description=@{repeating_lvl-4-spells_15_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_16_Cast" title="%{selected|repeating_lvl-4-spells_16_Cast}" value="/em casts @{repeating_lvl-4-spells_16_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_16_name}}} {{school=@{repeating_lvl-4-spells_16_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_16_cast-time}}} {{components=@{repeating_lvl-4-spells_16_components}}} {{range=@{repeating_lvl-4-spells_16_range}}} {{target=@{repeating_lvl-4-spells_16_targets}}} {{duration=@{repeating_lvl-4-spells_16_duration}}} {{saving_throw=@{repeating_lvl-4-spells_16_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_16_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_16_sr}}} {{spell_description=@{repeating_lvl-4-spells_16_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_17_Cast" title="%{selected|repeating_lvl-4-spells_17_Cast}" value="/em casts @{repeating_lvl-4-spells_17_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_17_name}}} {{school=@{repeating_lvl-4-spells_17_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_17_cast-time}}} {{components=@{repeating_lvl-4-spells_17_components}}} {{range=@{repeating_lvl-4-spells_17_range}}} {{target=@{repeating_lvl-4-spells_17_targets}}} {{duration=@{repeating_lvl-4-spells_17_duration}}} {{saving_throw=@{repeating_lvl-4-spells_17_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_17_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_17_sr}}} {{spell_description=@{repeating_lvl-4-spells_17_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_18_Cast" title="%{selected|repeating_lvl-4-spells_18_Cast}" value="/em casts @{repeating_lvl-4-spells_18_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_18_name}}} {{school=@{repeating_lvl-4-spells_18_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_18_cast-time}}} {{components=@{repeating_lvl-4-spells_18_components}}} {{range=@{repeating_lvl-4-spells_18_range}}} {{target=@{repeating_lvl-4-spells_18_targets}}} {{duration=@{repeating_lvl-4-spells_18_duration}}} {{saving_throw=@{repeating_lvl-4-spells_18_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_18_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_18_sr}}} {{spell_description=@{repeating_lvl-4-spells_18_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_19_Cast" title="%{selected|repeating_lvl-4-spells_19_Cast}" value="/em casts @{repeating_lvl-4-spells_19_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_19_name}}} {{school=@{repeating_lvl-4-spells_19_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_19_cast-time}}} {{components=@{repeating_lvl-4-spells_19_components}}} {{range=@{repeating_lvl-4-spells_19_range}}} {{target=@{repeating_lvl-4-spells_19_targets}}} {{duration=@{repeating_lvl-4-spells_19_duration}}} {{saving_throw=@{repeating_lvl-4-spells_19_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_19_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_19_sr}}} {{spell_description=@{repeating_lvl-4-spells_19_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_20_Cast" title="%{selected|repeating_lvl-4-spells_20_Cast}" value="/em casts @{repeating_lvl-4-spells_20_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_20_name}}} {{school=@{repeating_lvl-4-spells_20_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_20_cast-time}}} {{components=@{repeating_lvl-4-spells_20_components}}} {{range=@{repeating_lvl-4-spells_20_range}}} {{target=@{repeating_lvl-4-spells_20_targets}}} {{duration=@{repeating_lvl-4-spells_20_duration}}} {{saving_throw=@{repeating_lvl-4-spells_20_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_20_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_20_sr}}} {{spell_description=@{repeating_lvl-4-spells_20_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_21_Cast" title="%{selected|repeating_lvl-4-spells_21_Cast}" value="/em casts @{repeating_lvl-4-spells_21_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_21_name}}} {{school=@{repeating_lvl-4-spells_21_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_21_cast-time}}} {{components=@{repeating_lvl-4-spells_21_components}}} {{range=@{repeating_lvl-4-spells_21_range}}} {{target=@{repeating_lvl-4-spells_21_targets}}} {{duration=@{repeating_lvl-4-spells_21_duration}}} {{saving_throw=@{repeating_lvl-4-spells_21_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_21_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_21_sr}}} {{spell_description=@{repeating_lvl-4-spells_21_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_22_Cast" title="%{selected|repeating_lvl-4-spells_22_Cast}" value="/em casts @{repeating_lvl-4-spells_22_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_22_name}}} {{school=@{repeating_lvl-4-spells_22_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_22_cast-time}}} {{components=@{repeating_lvl-4-spells_22_components}}} {{range=@{repeating_lvl-4-spells_22_range}}} {{target=@{repeating_lvl-4-spells_22_targets}}} {{duration=@{repeating_lvl-4-spells_22_duration}}} {{saving_throw=@{repeating_lvl-4-spells_22_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_22_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_22_sr}}} {{spell_description=@{repeating_lvl-4-spells_22_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_23_Cast" title="%{selected|repeating_lvl-4-spells_23_Cast}" value="/em casts @{repeating_lvl-4-spells_23_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_23_name}}} {{school=@{repeating_lvl-4-spells_23_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_23_cast-time}}} {{components=@{repeating_lvl-4-spells_23_components}}} {{range=@{repeating_lvl-4-spells_23_range}}} {{target=@{repeating_lvl-4-spells_23_targets}}} {{duration=@{repeating_lvl-4-spells_23_duration}}} {{saving_throw=@{repeating_lvl-4-spells_23_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_23_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_23_sr}}} {{spell_description=@{repeating_lvl-4-spells_23_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_24_Cast" title="%{selected|repeating_lvl-4-spells_24_Cast}" value="/em casts @{repeating_lvl-4-spells_24_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_24_name}}} {{school=@{repeating_lvl-4-spells_24_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_24_cast-time}}} {{components=@{repeating_lvl-4-spells_24_components}}} {{range=@{repeating_lvl-4-spells_24_range}}} {{target=@{repeating_lvl-4-spells_24_targets}}} {{duration=@{repeating_lvl-4-spells_24_duration}}} {{saving_throw=@{repeating_lvl-4-spells_24_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_24_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_24_sr}}} {{spell_description=@{repeating_lvl-4-spells_24_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_25_Cast" title="%{selected|repeating_lvl-4-spells_25_Cast}" value="/em casts @{repeating_lvl-4-spells_25_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_25_name}}} {{school=@{repeating_lvl-4-spells_25_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_25_cast-time}}} {{components=@{repeating_lvl-4-spells_25_components}}} {{range=@{repeating_lvl-4-spells_25_range}}} {{target=@{repeating_lvl-4-spells_25_targets}}} {{duration=@{repeating_lvl-4-spells_25_duration}}} {{saving_throw=@{repeating_lvl-4-spells_25_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_25_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_25_sr}}} {{spell_description=@{repeating_lvl-4-spells_25_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-4-spells_26_Cast" title="%{selected|repeating_lvl-4-spells_26_Cast}" value="/em casts @{repeating_lvl-4-spells_26_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-4-spells_26_name}}} {{school=@{repeating_lvl-4-spells_26_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-4-spells_26_cast-time}}} {{components=@{repeating_lvl-4-spells_26_components}}} {{range=@{repeating_lvl-4-spells_26_range}}} {{target=@{repeating_lvl-4-spells_26_targets}}} {{duration=@{repeating_lvl-4-spells_26_duration}}} {{saving_throw=@{repeating_lvl-4-spells_26_save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{repeating_lvl-4-spells_26_DC-mod}]]}} {{sr=@{repeating_lvl-4-spells_26_sr}}} {{spell_description=@{repeating_lvl-4-spells_26_description}}}"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-sect">
+			<div class="sheet-table">
+				<span class="sheet-table-name">Level 4 Spells</span>
+			</div>
+			<fieldset class="repeating_lvl-4-spells">
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
+                </div>
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>					
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_duration}" type="text" value="N/A" name="attr_duration" placeholder="Duration"><br>Duration</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
+					<span class="sheet-table-data sheet-center sheet-small-label">
+						<select title="@{repeating_lvl-4-spells_X_sr}" name="attr_sr">
+							<option value="" selected>Select SR</option>
+							<option value="Yes">Yes</option>
+							<option value="No">No</option>
+						</select>
+						<br>SR
+					</span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-4-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_lvl-4-spells_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-4-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-4-spells_X_macro-text}" name="attr_macro-text">/em casts @{name}!&#x00A;&{template:pf_spell} {{name=@{name}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[@{spellclass-0-level-4-savedc} + @{DC-mod}]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+    <div>
+		<b>Level 5 Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{lvl-5-spells-show}" name="attr_lvl-5-spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Level 5 Spell Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_0_Cast" title="%{selected|repeating_lvl-5-spells_0_Cast}" value="/em casts @{repeating_lvl-5-spells_0_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_0_name}}} {{school=@{repeating_lvl-5-spells_0_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_0_cast-time}}} {{components=@{repeating_lvl-5-spells_0_components}}} {{range=@{repeating_lvl-5-spells_0_range}}} {{target=@{repeating_lvl-5-spells_0_targets}}} {{duration=@{repeating_lvl-5-spells_0_duration}}} {{saving_throw=@{repeating_lvl-5-spells_0_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_0_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_0_sr}}} {{spell_description=@{repeating_lvl-5-spells_0_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_1_Cast" title="%{selected|repeating_lvl-5-spells_1_Cast}" value="/em casts @{repeating_lvl-5-spells_1_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_1_name}}} {{school=@{repeating_lvl-5-spells_1_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_1_cast-time}}} {{components=@{repeating_lvl-5-spells_1_components}}} {{range=@{repeating_lvl-5-spells_1_range}}} {{target=@{repeating_lvl-5-spells_1_targets}}} {{duration=@{repeating_lvl-5-spells_1_duration}}} {{saving_throw=@{repeating_lvl-5-spells_1_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_1_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_1_sr}}} {{spell_description=@{repeating_lvl-5-spells_1_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_2_Cast" title="%{selected|repeating_lvl-5-spells_2_Cast}" value="/em casts @{repeating_lvl-5-spells_2_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_2_name}}} {{school=@{repeating_lvl-5-spells_2_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_2_cast-time}}} {{components=@{repeating_lvl-5-spells_2_components}}} {{range=@{repeating_lvl-5-spells_2_range}}} {{target=@{repeating_lvl-5-spells_2_targets}}} {{duration=@{repeating_lvl-5-spells_2_duration}}} {{saving_throw=@{repeating_lvl-5-spells_2_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_2_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_2_sr}}} {{spell_description=@{repeating_lvl-5-spells_2_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_3_Cast" title="%{selected|repeating_lvl-5-spells_3_Cast}" value="/em casts @{repeating_lvl-5-spells_3_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_3_name}}} {{school=@{repeating_lvl-5-spells_3_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_3_cast-time}}} {{components=@{repeating_lvl-5-spells_3_components}}} {{range=@{repeating_lvl-5-spells_3_range}}} {{target=@{repeating_lvl-5-spells_3_targets}}} {{duration=@{repeating_lvl-5-spells_3_duration}}} {{saving_throw=@{repeating_lvl-5-spells_3_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_3_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_3_sr}}} {{spell_description=@{repeating_lvl-5-spells_3_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_4_Cast" title="%{selected|repeating_lvl-5-spells_4_Cast}" value="/em casts @{repeating_lvl-5-spells_4_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_4_name}}} {{school=@{repeating_lvl-5-spells_4_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_4_cast-time}}} {{components=@{repeating_lvl-5-spells_4_components}}} {{range=@{repeating_lvl-5-spells_4_range}}} {{target=@{repeating_lvl-5-spells_4_targets}}} {{duration=@{repeating_lvl-5-spells_4_duration}}} {{saving_throw=@{repeating_lvl-5-spells_4_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_4_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_4_sr}}} {{spell_description=@{repeating_lvl-5-spells_4_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_5_Cast" title="%{selected|repeating_lvl-5-spells_5_Cast}" value="/em casts @{repeating_lvl-5-spells_5_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_5_name}}} {{school=@{repeating_lvl-5-spells_5_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_5_cast-time}}} {{components=@{repeating_lvl-5-spells_5_components}}} {{range=@{repeating_lvl-5-spells_5_range}}} {{target=@{repeating_lvl-5-spells_5_targets}}} {{duration=@{repeating_lvl-5-spells_5_duration}}} {{saving_throw=@{repeating_lvl-5-spells_5_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_5_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_5_sr}}} {{spell_description=@{repeating_lvl-5-spells_5_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_6_Cast" title="%{selected|repeating_lvl-5-spells_6_Cast}" value="/em casts @{repeating_lvl-5-spells_6_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_6_name}}} {{school=@{repeating_lvl-5-spells_6_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_6_cast-time}}} {{components=@{repeating_lvl-5-spells_6_components}}} {{range=@{repeating_lvl-5-spells_6_range}}} {{target=@{repeating_lvl-5-spells_6_targets}}} {{duration=@{repeating_lvl-5-spells_6_duration}}} {{saving_throw=@{repeating_lvl-5-spells_6_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_6_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_6_sr}}} {{spell_description=@{repeating_lvl-5-spells_6_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_7_Cast" title="%{selected|repeating_lvl-5-spells_7_Cast}" value="/em casts @{repeating_lvl-5-spells_7_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_7_name}}} {{school=@{repeating_lvl-5-spells_7_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_7_cast-time}}} {{components=@{repeating_lvl-5-spells_7_components}}} {{range=@{repeating_lvl-5-spells_7_range}}} {{target=@{repeating_lvl-5-spells_7_targets}}} {{duration=@{repeating_lvl-5-spells_7_duration}}} {{saving_throw=@{repeating_lvl-5-spells_7_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_7_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_7_sr}}} {{spell_description=@{repeating_lvl-5-spells_7_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_8_Cast" title="%{selected|repeating_lvl-5-spells_8_Cast}" value="/em casts @{repeating_lvl-5-spells_8_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_8_name}}} {{school=@{repeating_lvl-5-spells_8_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_8_cast-time}}} {{components=@{repeating_lvl-5-spells_8_components}}} {{range=@{repeating_lvl-5-spells_8_range}}} {{target=@{repeating_lvl-5-spells_8_targets}}} {{duration=@{repeating_lvl-5-spells_8_duration}}} {{saving_throw=@{repeating_lvl-5-spells_8_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_8_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_8_sr}}} {{spell_description=@{repeating_lvl-5-spells_8_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_9_Cast" title="%{selected|repeating_lvl-5-spells_9_Cast}" value="/em casts @{repeating_lvl-5-spells_9_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_9_name}}} {{school=@{repeating_lvl-5-spells_9_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_9_cast-time}}} {{components=@{repeating_lvl-5-spells_9_components}}} {{range=@{repeating_lvl-5-spells_9_range}}} {{target=@{repeating_lvl-5-spells_9_targets}}} {{duration=@{repeating_lvl-5-spells_9_duration}}} {{saving_throw=@{repeating_lvl-5-spells_9_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_9_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_9_sr}}} {{spell_description=@{repeating_lvl-5-spells_9_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_10_Cast" title="%{selected|repeating_lvl-5-spells_10_Cast}" value="/em casts @{repeating_lvl-5-spells_10_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_10_name}}} {{school=@{repeating_lvl-5-spells_10_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_10_cast-time}}} {{components=@{repeating_lvl-5-spells_10_components}}} {{range=@{repeating_lvl-5-spells_10_range}}} {{target=@{repeating_lvl-5-spells_10_targets}}} {{duration=@{repeating_lvl-5-spells_10_duration}}} {{saving_throw=@{repeating_lvl-5-spells_10_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_10_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_10_sr}}} {{spell_description=@{repeating_lvl-5-spells_10_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_11_Cast" title="%{selected|repeating_lvl-5-spells_11_Cast}" value="/em casts @{repeating_lvl-5-spells_11_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_11_name}}} {{school=@{repeating_lvl-5-spells_11_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_11_cast-time}}} {{components=@{repeating_lvl-5-spells_11_components}}} {{range=@{repeating_lvl-5-spells_11_range}}} {{target=@{repeating_lvl-5-spells_11_targets}}} {{duration=@{repeating_lvl-5-spells_11_duration}}} {{saving_throw=@{repeating_lvl-5-spells_11_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_11_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_11_sr}}} {{spell_description=@{repeating_lvl-5-spells_11_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_12_Cast" title="%{selected|repeating_lvl-5-spells_12_Cast}" value="/em casts @{repeating_lvl-5-spells_12_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_12_name}}} {{school=@{repeating_lvl-5-spells_12_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_12_cast-time}}} {{components=@{repeating_lvl-5-spells_12_components}}} {{range=@{repeating_lvl-5-spells_12_range}}} {{target=@{repeating_lvl-5-spells_12_targets}}} {{duration=@{repeating_lvl-5-spells_12_duration}}} {{saving_throw=@{repeating_lvl-5-spells_12_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_12_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_12_sr}}} {{spell_description=@{repeating_lvl-5-spells_12_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_13_Cast" title="%{selected|repeating_lvl-5-spells_13_Cast}" value="/em casts @{repeating_lvl-5-spells_13_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_13_name}}} {{school=@{repeating_lvl-5-spells_13_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_13_cast-time}}} {{components=@{repeating_lvl-5-spells_13_components}}} {{range=@{repeating_lvl-5-spells_13_range}}} {{target=@{repeating_lvl-5-spells_13_targets}}} {{duration=@{repeating_lvl-5-spells_13_duration}}} {{saving_throw=@{repeating_lvl-5-spells_13_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_13_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_13_sr}}} {{spell_description=@{repeating_lvl-5-spells_13_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_14_Cast" title="%{selected|repeating_lvl-5-spells_14_Cast}" value="/em casts @{repeating_lvl-5-spells_14_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_14_name}}} {{school=@{repeating_lvl-5-spells_14_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_14_cast-time}}} {{components=@{repeating_lvl-5-spells_14_components}}} {{range=@{repeating_lvl-5-spells_14_range}}} {{target=@{repeating_lvl-5-spells_14_targets}}} {{duration=@{repeating_lvl-5-spells_14_duration}}} {{saving_throw=@{repeating_lvl-5-spells_14_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_14_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_14_sr}}} {{spell_description=@{repeating_lvl-5-spells_14_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_15_Cast" title="%{selected|repeating_lvl-5-spells_15_Cast}" value="/em casts @{repeating_lvl-5-spells_15_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_15_name}}} {{school=@{repeating_lvl-5-spells_15_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_15_cast-time}}} {{components=@{repeating_lvl-5-spells_15_components}}} {{range=@{repeating_lvl-5-spells_15_range}}} {{target=@{repeating_lvl-5-spells_15_targets}}} {{duration=@{repeating_lvl-5-spells_15_duration}}} {{saving_throw=@{repeating_lvl-5-spells_15_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_15_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_15_sr}}} {{spell_description=@{repeating_lvl-5-spells_15_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_16_Cast" title="%{selected|repeating_lvl-5-spells_16_Cast}" value="/em casts @{repeating_lvl-5-spells_16_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_16_name}}} {{school=@{repeating_lvl-5-spells_16_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_16_cast-time}}} {{components=@{repeating_lvl-5-spells_16_components}}} {{range=@{repeating_lvl-5-spells_16_range}}} {{target=@{repeating_lvl-5-spells_16_targets}}} {{duration=@{repeating_lvl-5-spells_16_duration}}} {{saving_throw=@{repeating_lvl-5-spells_16_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_16_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_16_sr}}} {{spell_description=@{repeating_lvl-5-spells_16_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_17_Cast" title="%{selected|repeating_lvl-5-spells_17_Cast}" value="/em casts @{repeating_lvl-5-spells_17_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_17_name}}} {{school=@{repeating_lvl-5-spells_17_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_17_cast-time}}} {{components=@{repeating_lvl-5-spells_17_components}}} {{range=@{repeating_lvl-5-spells_17_range}}} {{target=@{repeating_lvl-5-spells_17_targets}}} {{duration=@{repeating_lvl-5-spells_17_duration}}} {{saving_throw=@{repeating_lvl-5-spells_17_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_17_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_17_sr}}} {{spell_description=@{repeating_lvl-5-spells_17_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_18_Cast" title="%{selected|repeating_lvl-5-spells_18_Cast}" value="/em casts @{repeating_lvl-5-spells_18_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_18_name}}} {{school=@{repeating_lvl-5-spells_18_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_18_cast-time}}} {{components=@{repeating_lvl-5-spells_18_components}}} {{range=@{repeating_lvl-5-spells_18_range}}} {{target=@{repeating_lvl-5-spells_18_targets}}} {{duration=@{repeating_lvl-5-spells_18_duration}}} {{saving_throw=@{repeating_lvl-5-spells_18_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_18_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_18_sr}}} {{spell_description=@{repeating_lvl-5-spells_18_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_19_Cast" title="%{selected|repeating_lvl-5-spells_19_Cast}" value="/em casts @{repeating_lvl-5-spells_19_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_19_name}}} {{school=@{repeating_lvl-5-spells_19_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_19_cast-time}}} {{components=@{repeating_lvl-5-spells_19_components}}} {{range=@{repeating_lvl-5-spells_19_range}}} {{target=@{repeating_lvl-5-spells_19_targets}}} {{duration=@{repeating_lvl-5-spells_19_duration}}} {{saving_throw=@{repeating_lvl-5-spells_19_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_19_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_19_sr}}} {{spell_description=@{repeating_lvl-5-spells_19_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_20_Cast" title="%{selected|repeating_lvl-5-spells_20_Cast}" value="/em casts @{repeating_lvl-5-spells_20_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_20_name}}} {{school=@{repeating_lvl-5-spells_20_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_20_cast-time}}} {{components=@{repeating_lvl-5-spells_20_components}}} {{range=@{repeating_lvl-5-spells_20_range}}} {{target=@{repeating_lvl-5-spells_20_targets}}} {{duration=@{repeating_lvl-5-spells_20_duration}}} {{saving_throw=@{repeating_lvl-5-spells_20_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_20_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_20_sr}}} {{spell_description=@{repeating_lvl-5-spells_20_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_21_Cast" title="%{selected|repeating_lvl-5-spells_21_Cast}" value="/em casts @{repeating_lvl-5-spells_21_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_21_name}}} {{school=@{repeating_lvl-5-spells_21_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_21_cast-time}}} {{components=@{repeating_lvl-5-spells_21_components}}} {{range=@{repeating_lvl-5-spells_21_range}}} {{target=@{repeating_lvl-5-spells_21_targets}}} {{duration=@{repeating_lvl-5-spells_21_duration}}} {{saving_throw=@{repeating_lvl-5-spells_21_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_21_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_21_sr}}} {{spell_description=@{repeating_lvl-5-spells_21_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_22_Cast" title="%{selected|repeating_lvl-5-spells_22_Cast}" value="/em casts @{repeating_lvl-5-spells_22_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_22_name}}} {{school=@{repeating_lvl-5-spells_22_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_22_cast-time}}} {{components=@{repeating_lvl-5-spells_22_components}}} {{range=@{repeating_lvl-5-spells_22_range}}} {{target=@{repeating_lvl-5-spells_22_targets}}} {{duration=@{repeating_lvl-5-spells_22_duration}}} {{saving_throw=@{repeating_lvl-5-spells_22_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_22_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_22_sr}}} {{spell_description=@{repeating_lvl-5-spells_22_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_23_Cast" title="%{selected|repeating_lvl-5-spells_23_Cast}" value="/em casts @{repeating_lvl-5-spells_23_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_23_name}}} {{school=@{repeating_lvl-5-spells_23_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_23_cast-time}}} {{components=@{repeating_lvl-5-spells_23_components}}} {{range=@{repeating_lvl-5-spells_23_range}}} {{target=@{repeating_lvl-5-spells_23_targets}}} {{duration=@{repeating_lvl-5-spells_23_duration}}} {{saving_throw=@{repeating_lvl-5-spells_23_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_23_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_23_sr}}} {{spell_description=@{repeating_lvl-5-spells_23_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_24_Cast" title="%{selected|repeating_lvl-5-spells_24_Cast}" value="/em casts @{repeating_lvl-5-spells_24_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_24_name}}} {{school=@{repeating_lvl-5-spells_24_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_24_cast-time}}} {{components=@{repeating_lvl-5-spells_24_components}}} {{range=@{repeating_lvl-5-spells_24_range}}} {{target=@{repeating_lvl-5-spells_24_targets}}} {{duration=@{repeating_lvl-5-spells_24_duration}}} {{saving_throw=@{repeating_lvl-5-spells_24_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_24_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_24_sr}}} {{spell_description=@{repeating_lvl-5-spells_24_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_25_Cast" title="%{selected|repeating_lvl-5-spells_25_Cast}" value="/em casts @{repeating_lvl-5-spells_25_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_25_name}}} {{school=@{repeating_lvl-5-spells_25_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_25_cast-time}}} {{components=@{repeating_lvl-5-spells_25_components}}} {{range=@{repeating_lvl-5-spells_25_range}}} {{target=@{repeating_lvl-5-spells_25_targets}}} {{duration=@{repeating_lvl-5-spells_25_duration}}} {{saving_throw=@{repeating_lvl-5-spells_25_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_25_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_25_sr}}} {{spell_description=@{repeating_lvl-5-spells_25_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-5-spells_26_Cast" title="%{selected|repeating_lvl-5-spells_26_Cast}" value="/em casts @{repeating_lvl-5-spells_26_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-5-spells_26_name}}} {{school=@{repeating_lvl-5-spells_26_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-5-spells_26_cast-time}}} {{components=@{repeating_lvl-5-spells_26_components}}} {{range=@{repeating_lvl-5-spells_26_range}}} {{target=@{repeating_lvl-5-spells_26_targets}}} {{duration=@{repeating_lvl-5-spells_26_duration}}} {{saving_throw=@{repeating_lvl-5-spells_26_save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{repeating_lvl-5-spells_26_DC-mod}]]}} {{sr=@{repeating_lvl-5-spells_26_sr}}} {{spell_description=@{repeating_lvl-5-spells_26_description}}}"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-sect">
+			<div class="sheet-table">
+				<span class="sheet-table-name">Level 5 Spells</span>
+			</div>
+			<fieldset class="repeating_lvl-5-spells">
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
+                </div>
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>					
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_duration}" type="text" value="N/A" name="attr_duration" placeholder="Duration"><br>Duration</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
+					<span class="sheet-table-data sheet-center sheet-small-label">
+						<select title="@{repeating_lvl-5-spells_X_sr}" name="attr_sr">
+							<option value="" selected>Select SR</option>
+							<option value="Yes">Yes</option>
+							<option value="No">No</option>
+						</select>
+						<br>SR
+					</span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-5-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_lvl-5-spells_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-5-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-5-spells_X_macro-text}" name="attr_macro-text">/em casts @{name}!&#x00A;&{template:pf_spell} {{name=@{name}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[@{spellclass-0-level-5-savedc} + @{DC-mod}]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+	<div>
+		<b>Level 6 Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{lvl-6-spells-show}" name="attr_lvl-6-spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Level 6 Spell Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_0_Cast" title="%{selected|repeating_lvl-6-spells_0_Cast}" value="/em casts @{repeating_lvl-6-spells_0_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_0_name}}} {{school=@{repeating_lvl-6-spells_0_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_0_cast-time}}} {{components=@{repeating_lvl-6-spells_0_components}}} {{range=@{repeating_lvl-6-spells_0_range}}} {{target=@{repeating_lvl-6-spells_0_targets}}} {{duration=@{repeating_lvl-6-spells_0_duration}}} {{saving_throw=@{repeating_lvl-6-spells_0_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_0_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_0_sr}}} {{spell_description=@{repeating_lvl-6-spells_0_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_1_Cast" title="%{selected|repeating_lvl-6-spells_1_Cast}" value="/em casts @{repeating_lvl-6-spells_1_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_1_name}}} {{school=@{repeating_lvl-6-spells_1_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_1_cast-time}}} {{components=@{repeating_lvl-6-spells_1_components}}} {{range=@{repeating_lvl-6-spells_1_range}}} {{target=@{repeating_lvl-6-spells_1_targets}}} {{duration=@{repeating_lvl-6-spells_1_duration}}} {{saving_throw=@{repeating_lvl-6-spells_1_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_1_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_1_sr}}} {{spell_description=@{repeating_lvl-6-spells_1_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_2_Cast" title="%{selected|repeating_lvl-6-spells_2_Cast}" value="/em casts @{repeating_lvl-6-spells_2_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_2_name}}} {{school=@{repeating_lvl-6-spells_2_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_2_cast-time}}} {{components=@{repeating_lvl-6-spells_2_components}}} {{range=@{repeating_lvl-6-spells_2_range}}} {{target=@{repeating_lvl-6-spells_2_targets}}} {{duration=@{repeating_lvl-6-spells_2_duration}}} {{saving_throw=@{repeating_lvl-6-spells_2_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_2_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_2_sr}}} {{spell_description=@{repeating_lvl-6-spells_2_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_3_Cast" title="%{selected|repeating_lvl-6-spells_3_Cast}" value="/em casts @{repeating_lvl-6-spells_3_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_3_name}}} {{school=@{repeating_lvl-6-spells_3_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_3_cast-time}}} {{components=@{repeating_lvl-6-spells_3_components}}} {{range=@{repeating_lvl-6-spells_3_range}}} {{target=@{repeating_lvl-6-spells_3_targets}}} {{duration=@{repeating_lvl-6-spells_3_duration}}} {{saving_throw=@{repeating_lvl-6-spells_3_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_3_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_3_sr}}} {{spell_description=@{repeating_lvl-6-spells_3_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_4_Cast" title="%{selected|repeating_lvl-6-spells_4_Cast}" value="/em casts @{repeating_lvl-6-spells_4_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_4_name}}} {{school=@{repeating_lvl-6-spells_4_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_4_cast-time}}} {{components=@{repeating_lvl-6-spells_4_components}}} {{range=@{repeating_lvl-6-spells_4_range}}} {{target=@{repeating_lvl-6-spells_4_targets}}} {{duration=@{repeating_lvl-6-spells_4_duration}}} {{saving_throw=@{repeating_lvl-6-spells_4_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_4_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_4_sr}}} {{spell_description=@{repeating_lvl-6-spells_4_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_5_Cast" title="%{selected|repeating_lvl-6-spells_5_Cast}" value="/em casts @{repeating_lvl-6-spells_5_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_5_name}}} {{school=@{repeating_lvl-6-spells_5_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_5_cast-time}}} {{components=@{repeating_lvl-6-spells_5_components}}} {{range=@{repeating_lvl-6-spells_5_range}}} {{target=@{repeating_lvl-6-spells_5_targets}}} {{duration=@{repeating_lvl-6-spells_5_duration}}} {{saving_throw=@{repeating_lvl-6-spells_5_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_5_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_5_sr}}} {{spell_description=@{repeating_lvl-6-spells_5_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_6_Cast" title="%{selected|repeating_lvl-6-spells_6_Cast}" value="/em casts @{repeating_lvl-6-spells_6_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_6_name}}} {{school=@{repeating_lvl-6-spells_6_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_6_cast-time}}} {{components=@{repeating_lvl-6-spells_6_components}}} {{range=@{repeating_lvl-6-spells_6_range}}} {{target=@{repeating_lvl-6-spells_6_targets}}} {{duration=@{repeating_lvl-6-spells_6_duration}}} {{saving_throw=@{repeating_lvl-6-spells_6_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_6_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_6_sr}}} {{spell_description=@{repeating_lvl-6-spells_6_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_7_Cast" title="%{selected|repeating_lvl-6-spells_7_Cast}" value="/em casts @{repeating_lvl-6-spells_7_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_7_name}}} {{school=@{repeating_lvl-6-spells_7_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_7_cast-time}}} {{components=@{repeating_lvl-6-spells_7_components}}} {{range=@{repeating_lvl-6-spells_7_range}}} {{target=@{repeating_lvl-6-spells_7_targets}}} {{duration=@{repeating_lvl-6-spells_7_duration}}} {{saving_throw=@{repeating_lvl-6-spells_7_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_7_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_7_sr}}} {{spell_description=@{repeating_lvl-6-spells_7_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_8_Cast" title="%{selected|repeating_lvl-6-spells_8_Cast}" value="/em casts @{repeating_lvl-6-spells_8_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_8_name}}} {{school=@{repeating_lvl-6-spells_8_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_8_cast-time}}} {{components=@{repeating_lvl-6-spells_8_components}}} {{range=@{repeating_lvl-6-spells_8_range}}} {{target=@{repeating_lvl-6-spells_8_targets}}} {{duration=@{repeating_lvl-6-spells_8_duration}}} {{saving_throw=@{repeating_lvl-6-spells_8_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_8_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_8_sr}}} {{spell_description=@{repeating_lvl-6-spells_8_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_9_Cast" title="%{selected|repeating_lvl-6-spells_9_Cast}" value="/em casts @{repeating_lvl-6-spells_9_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_9_name}}} {{school=@{repeating_lvl-6-spells_9_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_9_cast-time}}} {{components=@{repeating_lvl-6-spells_9_components}}} {{range=@{repeating_lvl-6-spells_9_range}}} {{target=@{repeating_lvl-6-spells_9_targets}}} {{duration=@{repeating_lvl-6-spells_9_duration}}} {{saving_throw=@{repeating_lvl-6-spells_9_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_9_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_9_sr}}} {{spell_description=@{repeating_lvl-6-spells_9_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_10_Cast" title="%{selected|repeating_lvl-6-spells_10_Cast}" value="/em casts @{repeating_lvl-6-spells_10_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_10_name}}} {{school=@{repeating_lvl-6-spells_10_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_10_cast-time}}} {{components=@{repeating_lvl-6-spells_10_components}}} {{range=@{repeating_lvl-6-spells_10_range}}} {{target=@{repeating_lvl-6-spells_10_targets}}} {{duration=@{repeating_lvl-6-spells_10_duration}}} {{saving_throw=@{repeating_lvl-6-spells_10_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_10_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_10_sr}}} {{spell_description=@{repeating_lvl-6-spells_10_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_11_Cast" title="%{selected|repeating_lvl-6-spells_11_Cast}" value="/em casts @{repeating_lvl-6-spells_11_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_11_name}}} {{school=@{repeating_lvl-6-spells_11_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_11_cast-time}}} {{components=@{repeating_lvl-6-spells_11_components}}} {{range=@{repeating_lvl-6-spells_11_range}}} {{target=@{repeating_lvl-6-spells_11_targets}}} {{duration=@{repeating_lvl-6-spells_11_duration}}} {{saving_throw=@{repeating_lvl-6-spells_11_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_11_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_11_sr}}} {{spell_description=@{repeating_lvl-6-spells_11_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_12_Cast" title="%{selected|repeating_lvl-6-spells_12_Cast}" value="/em casts @{repeating_lvl-6-spells_12_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_12_name}}} {{school=@{repeating_lvl-6-spells_12_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_12_cast-time}}} {{components=@{repeating_lvl-6-spells_12_components}}} {{range=@{repeating_lvl-6-spells_12_range}}} {{target=@{repeating_lvl-6-spells_12_targets}}} {{duration=@{repeating_lvl-6-spells_12_duration}}} {{saving_throw=@{repeating_lvl-6-spells_12_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_12_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_12_sr}}} {{spell_description=@{repeating_lvl-6-spells_12_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_13_Cast" title="%{selected|repeating_lvl-6-spells_13_Cast}" value="/em casts @{repeating_lvl-6-spells_13_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_13_name}}} {{school=@{repeating_lvl-6-spells_13_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_13_cast-time}}} {{components=@{repeating_lvl-6-spells_13_components}}} {{range=@{repeating_lvl-6-spells_13_range}}} {{target=@{repeating_lvl-6-spells_13_targets}}} {{duration=@{repeating_lvl-6-spells_13_duration}}} {{saving_throw=@{repeating_lvl-6-spells_13_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_13_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_13_sr}}} {{spell_description=@{repeating_lvl-6-spells_13_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_14_Cast" title="%{selected|repeating_lvl-6-spells_14_Cast}" value="/em casts @{repeating_lvl-6-spells_14_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_14_name}}} {{school=@{repeating_lvl-6-spells_14_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_14_cast-time}}} {{components=@{repeating_lvl-6-spells_14_components}}} {{range=@{repeating_lvl-6-spells_14_range}}} {{target=@{repeating_lvl-6-spells_14_targets}}} {{duration=@{repeating_lvl-6-spells_14_duration}}} {{saving_throw=@{repeating_lvl-6-spells_14_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_14_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_14_sr}}} {{spell_description=@{repeating_lvl-6-spells_14_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_15_Cast" title="%{selected|repeating_lvl-6-spells_15_Cast}" value="/em casts @{repeating_lvl-6-spells_15_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_15_name}}} {{school=@{repeating_lvl-6-spells_15_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_15_cast-time}}} {{components=@{repeating_lvl-6-spells_15_components}}} {{range=@{repeating_lvl-6-spells_15_range}}} {{target=@{repeating_lvl-6-spells_15_targets}}} {{duration=@{repeating_lvl-6-spells_15_duration}}} {{saving_throw=@{repeating_lvl-6-spells_15_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_15_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_15_sr}}} {{spell_description=@{repeating_lvl-6-spells_15_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_16_Cast" title="%{selected|repeating_lvl-6-spells_16_Cast}" value="/em casts @{repeating_lvl-6-spells_16_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_16_name}}} {{school=@{repeating_lvl-6-spells_16_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_16_cast-time}}} {{components=@{repeating_lvl-6-spells_16_components}}} {{range=@{repeating_lvl-6-spells_16_range}}} {{target=@{repeating_lvl-6-spells_16_targets}}} {{duration=@{repeating_lvl-6-spells_16_duration}}} {{saving_throw=@{repeating_lvl-6-spells_16_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_16_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_16_sr}}} {{spell_description=@{repeating_lvl-6-spells_16_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_17_Cast" title="%{selected|repeating_lvl-6-spells_17_Cast}" value="/em casts @{repeating_lvl-6-spells_17_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_17_name}}} {{school=@{repeating_lvl-6-spells_17_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_17_cast-time}}} {{components=@{repeating_lvl-6-spells_17_components}}} {{range=@{repeating_lvl-6-spells_17_range}}} {{target=@{repeating_lvl-6-spells_17_targets}}} {{duration=@{repeating_lvl-6-spells_17_duration}}} {{saving_throw=@{repeating_lvl-6-spells_17_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_17_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_17_sr}}} {{spell_description=@{repeating_lvl-6-spells_17_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_18_Cast" title="%{selected|repeating_lvl-6-spells_18_Cast}" value="/em casts @{repeating_lvl-6-spells_18_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_18_name}}} {{school=@{repeating_lvl-6-spells_18_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_18_cast-time}}} {{components=@{repeating_lvl-6-spells_18_components}}} {{range=@{repeating_lvl-6-spells_18_range}}} {{target=@{repeating_lvl-6-spells_18_targets}}} {{duration=@{repeating_lvl-6-spells_18_duration}}} {{saving_throw=@{repeating_lvl-6-spells_18_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_18_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_18_sr}}} {{spell_description=@{repeating_lvl-6-spells_18_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_19_Cast" title="%{selected|repeating_lvl-6-spells_19_Cast}" value="/em casts @{repeating_lvl-6-spells_19_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_19_name}}} {{school=@{repeating_lvl-6-spells_19_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_19_cast-time}}} {{components=@{repeating_lvl-6-spells_19_components}}} {{range=@{repeating_lvl-6-spells_19_range}}} {{target=@{repeating_lvl-6-spells_19_targets}}} {{duration=@{repeating_lvl-6-spells_19_duration}}} {{saving_throw=@{repeating_lvl-6-spells_19_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_19_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_19_sr}}} {{spell_description=@{repeating_lvl-6-spells_19_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_20_Cast" title="%{selected|repeating_lvl-6-spells_20_Cast}" value="/em casts @{repeating_lvl-6-spells_20_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_20_name}}} {{school=@{repeating_lvl-6-spells_20_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_20_cast-time}}} {{components=@{repeating_lvl-6-spells_20_components}}} {{range=@{repeating_lvl-6-spells_20_range}}} {{target=@{repeating_lvl-6-spells_20_targets}}} {{duration=@{repeating_lvl-6-spells_20_duration}}} {{saving_throw=@{repeating_lvl-6-spells_20_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_20_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_20_sr}}} {{spell_description=@{repeating_lvl-6-spells_20_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_21_Cast" title="%{selected|repeating_lvl-6-spells_21_Cast}" value="/em casts @{repeating_lvl-6-spells_21_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_21_name}}} {{school=@{repeating_lvl-6-spells_21_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_21_cast-time}}} {{components=@{repeating_lvl-6-spells_21_components}}} {{range=@{repeating_lvl-6-spells_21_range}}} {{target=@{repeating_lvl-6-spells_21_targets}}} {{duration=@{repeating_lvl-6-spells_21_duration}}} {{saving_throw=@{repeating_lvl-6-spells_21_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_21_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_21_sr}}} {{spell_description=@{repeating_lvl-6-spells_21_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_22_Cast" title="%{selected|repeating_lvl-6-spells_22_Cast}" value="/em casts @{repeating_lvl-6-spells_22_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_22_name}}} {{school=@{repeating_lvl-6-spells_22_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_22_cast-time}}} {{components=@{repeating_lvl-6-spells_22_components}}} {{range=@{repeating_lvl-6-spells_22_range}}} {{target=@{repeating_lvl-6-spells_22_targets}}} {{duration=@{repeating_lvl-6-spells_22_duration}}} {{saving_throw=@{repeating_lvl-6-spells_22_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_22_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_22_sr}}} {{spell_description=@{repeating_lvl-6-spells_22_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_23_Cast" title="%{selected|repeating_lvl-6-spells_23_Cast}" value="/em casts @{repeating_lvl-6-spells_23_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_23_name}}} {{school=@{repeating_lvl-6-spells_23_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_23_cast-time}}} {{components=@{repeating_lvl-6-spells_23_components}}} {{range=@{repeating_lvl-6-spells_23_range}}} {{target=@{repeating_lvl-6-spells_23_targets}}} {{duration=@{repeating_lvl-6-spells_23_duration}}} {{saving_throw=@{repeating_lvl-6-spells_23_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_23_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_23_sr}}} {{spell_description=@{repeating_lvl-6-spells_23_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_24_Cast" title="%{selected|repeating_lvl-6-spells_24_Cast}" value="/em casts @{repeating_lvl-6-spells_24_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_24_name}}} {{school=@{repeating_lvl-6-spells_24_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_24_cast-time}}} {{components=@{repeating_lvl-6-spells_24_components}}} {{range=@{repeating_lvl-6-spells_24_range}}} {{target=@{repeating_lvl-6-spells_24_targets}}} {{duration=@{repeating_lvl-6-spells_24_duration}}} {{saving_throw=@{repeating_lvl-6-spells_24_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_24_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_24_sr}}} {{spell_description=@{repeating_lvl-6-spells_24_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_25_Cast" title="%{selected|repeating_lvl-6-spells_25_Cast}" value="/em casts @{repeating_lvl-6-spells_25_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_25_name}}} {{school=@{repeating_lvl-6-spells_25_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_25_cast-time}}} {{components=@{repeating_lvl-6-spells_25_components}}} {{range=@{repeating_lvl-6-spells_25_range}}} {{target=@{repeating_lvl-6-spells_25_targets}}} {{duration=@{repeating_lvl-6-spells_25_duration}}} {{saving_throw=@{repeating_lvl-6-spells_25_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_25_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_25_sr}}} {{spell_description=@{repeating_lvl-6-spells_25_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-6-spells_26_Cast" title="%{selected|repeating_lvl-6-spells_26_Cast}" value="/em casts @{repeating_lvl-6-spells_26_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-6-spells_26_name}}} {{school=@{repeating_lvl-6-spells_26_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-6-spells_26_cast-time}}} {{components=@{repeating_lvl-6-spells_26_components}}} {{range=@{repeating_lvl-6-spells_26_range}}} {{target=@{repeating_lvl-6-spells_26_targets}}} {{duration=@{repeating_lvl-6-spells_26_duration}}} {{saving_throw=@{repeating_lvl-6-spells_26_save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{repeating_lvl-6-spells_26_DC-mod}]]}} {{sr=@{repeating_lvl-6-spells_26_sr}}} {{spell_description=@{repeating_lvl-6-spells_26_description}}}"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-sect">
+			<div class="sheet-table">
+				<span class="sheet-table-name">Level 6 Spells</span>
+			</div>
+			<fieldset class="repeating_lvl-6-spells">
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
+                </div>
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>					
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_duration}" type="text" value="N/A" name="attr_duration" placeholder="Duration"><br>Duration</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
+					<span class="sheet-table-data sheet-center sheet-small-label">
+						<select title="@{repeating_lvl-6-spells_X_sr}" name="attr_sr">
+							<option value="" selected>Select SR</option>
+							<option value="Yes">Yes</option>
+							<option value="No">No</option>
+						</select>
+						<br>SR
+					</span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-6-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_lvl-6-spells_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-6-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-6-spells_X_macro-text}" name="attr_macro-text">/em casts @{name}!&#x00A;&{template:pf_spell} {{name=@{name}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[@{spellclass-0-level-6-savedc} + @{DC-mod}]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+	<div>
+		<b>Level 7 Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{lvl-7-spells-show}" name="attr_lvl-7-spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Level 7 Spell Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_0_Cast" title="%{selected|repeating_lvl-7-spells_0_Cast}" value="/em casts @{repeating_lvl-7-spells_0_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_0_name}}} {{school=@{repeating_lvl-7-spells_0_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_0_cast-time}}} {{components=@{repeating_lvl-7-spells_0_components}}} {{range=@{repeating_lvl-7-spells_0_range}}} {{target=@{repeating_lvl-7-spells_0_targets}}} {{duration=@{repeating_lvl-7-spells_0_duration}}} {{saving_throw=@{repeating_lvl-7-spells_0_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_0_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_0_sr}}} {{spell_description=@{repeating_lvl-7-spells_0_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_1_Cast" title="%{selected|repeating_lvl-7-spells_1_Cast}" value="/em casts @{repeating_lvl-7-spells_1_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_1_name}}} {{school=@{repeating_lvl-7-spells_1_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_1_cast-time}}} {{components=@{repeating_lvl-7-spells_1_components}}} {{range=@{repeating_lvl-7-spells_1_range}}} {{target=@{repeating_lvl-7-spells_1_targets}}} {{duration=@{repeating_lvl-7-spells_1_duration}}} {{saving_throw=@{repeating_lvl-7-spells_1_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_1_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_1_sr}}} {{spell_description=@{repeating_lvl-7-spells_1_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_2_Cast" title="%{selected|repeating_lvl-7-spells_2_Cast}" value="/em casts @{repeating_lvl-7-spells_2_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_2_name}}} {{school=@{repeating_lvl-7-spells_2_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_2_cast-time}}} {{components=@{repeating_lvl-7-spells_2_components}}} {{range=@{repeating_lvl-7-spells_2_range}}} {{target=@{repeating_lvl-7-spells_2_targets}}} {{duration=@{repeating_lvl-7-spells_2_duration}}} {{saving_throw=@{repeating_lvl-7-spells_2_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_2_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_2_sr}}} {{spell_description=@{repeating_lvl-7-spells_2_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_3_Cast" title="%{selected|repeating_lvl-7-spells_3_Cast}" value="/em casts @{repeating_lvl-7-spells_3_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_3_name}}} {{school=@{repeating_lvl-7-spells_3_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_3_cast-time}}} {{components=@{repeating_lvl-7-spells_3_components}}} {{range=@{repeating_lvl-7-spells_3_range}}} {{target=@{repeating_lvl-7-spells_3_targets}}} {{duration=@{repeating_lvl-7-spells_3_duration}}} {{saving_throw=@{repeating_lvl-7-spells_3_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_3_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_3_sr}}} {{spell_description=@{repeating_lvl-7-spells_3_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_4_Cast" title="%{selected|repeating_lvl-7-spells_4_Cast}" value="/em casts @{repeating_lvl-7-spells_4_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_4_name}}} {{school=@{repeating_lvl-7-spells_4_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_4_cast-time}}} {{components=@{repeating_lvl-7-spells_4_components}}} {{range=@{repeating_lvl-7-spells_4_range}}} {{target=@{repeating_lvl-7-spells_4_targets}}} {{duration=@{repeating_lvl-7-spells_4_duration}}} {{saving_throw=@{repeating_lvl-7-spells_4_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_4_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_4_sr}}} {{spell_description=@{repeating_lvl-7-spells_4_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_5_Cast" title="%{selected|repeating_lvl-7-spells_5_Cast}" value="/em casts @{repeating_lvl-7-spells_5_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_5_name}}} {{school=@{repeating_lvl-7-spells_5_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_5_cast-time}}} {{components=@{repeating_lvl-7-spells_5_components}}} {{range=@{repeating_lvl-7-spells_5_range}}} {{target=@{repeating_lvl-7-spells_5_targets}}} {{duration=@{repeating_lvl-7-spells_5_duration}}} {{saving_throw=@{repeating_lvl-7-spells_5_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_5_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_5_sr}}} {{spell_description=@{repeating_lvl-7-spells_5_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_6_Cast" title="%{selected|repeating_lvl-7-spells_6_Cast}" value="/em casts @{repeating_lvl-7-spells_6_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_6_name}}} {{school=@{repeating_lvl-7-spells_6_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_6_cast-time}}} {{components=@{repeating_lvl-7-spells_6_components}}} {{range=@{repeating_lvl-7-spells_6_range}}} {{target=@{repeating_lvl-7-spells_6_targets}}} {{duration=@{repeating_lvl-7-spells_6_duration}}} {{saving_throw=@{repeating_lvl-7-spells_6_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_6_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_6_sr}}} {{spell_description=@{repeating_lvl-7-spells_6_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_7_Cast" title="%{selected|repeating_lvl-7-spells_7_Cast}" value="/em casts @{repeating_lvl-7-spells_7_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_7_name}}} {{school=@{repeating_lvl-7-spells_7_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_7_cast-time}}} {{components=@{repeating_lvl-7-spells_7_components}}} {{range=@{repeating_lvl-7-spells_7_range}}} {{target=@{repeating_lvl-7-spells_7_targets}}} {{duration=@{repeating_lvl-7-spells_7_duration}}} {{saving_throw=@{repeating_lvl-7-spells_7_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_7_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_7_sr}}} {{spell_description=@{repeating_lvl-7-spells_7_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_8_Cast" title="%{selected|repeating_lvl-7-spells_8_Cast}" value="/em casts @{repeating_lvl-7-spells_8_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_8_name}}} {{school=@{repeating_lvl-7-spells_8_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_8_cast-time}}} {{components=@{repeating_lvl-7-spells_8_components}}} {{range=@{repeating_lvl-7-spells_8_range}}} {{target=@{repeating_lvl-7-spells_8_targets}}} {{duration=@{repeating_lvl-7-spells_8_duration}}} {{saving_throw=@{repeating_lvl-7-spells_8_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_8_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_8_sr}}} {{spell_description=@{repeating_lvl-7-spells_8_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_9_Cast" title="%{selected|repeating_lvl-7-spells_9_Cast}" value="/em casts @{repeating_lvl-7-spells_9_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_9_name}}} {{school=@{repeating_lvl-7-spells_9_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_9_cast-time}}} {{components=@{repeating_lvl-7-spells_9_components}}} {{range=@{repeating_lvl-7-spells_9_range}}} {{target=@{repeating_lvl-7-spells_9_targets}}} {{duration=@{repeating_lvl-7-spells_9_duration}}} {{saving_throw=@{repeating_lvl-7-spells_9_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_9_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_9_sr}}} {{spell_description=@{repeating_lvl-7-spells_9_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_10_Cast" title="%{selected|repeating_lvl-7-spells_10_Cast}" value="/em casts @{repeating_lvl-7-spells_10_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_10_name}}} {{school=@{repeating_lvl-7-spells_10_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_10_cast-time}}} {{components=@{repeating_lvl-7-spells_10_components}}} {{range=@{repeating_lvl-7-spells_10_range}}} {{target=@{repeating_lvl-7-spells_10_targets}}} {{duration=@{repeating_lvl-7-spells_10_duration}}} {{saving_throw=@{repeating_lvl-7-spells_10_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_10_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_10_sr}}} {{spell_description=@{repeating_lvl-7-spells_10_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_11_Cast" title="%{selected|repeating_lvl-7-spells_11_Cast}" value="/em casts @{repeating_lvl-7-spells_11_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_11_name}}} {{school=@{repeating_lvl-7-spells_11_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_11_cast-time}}} {{components=@{repeating_lvl-7-spells_11_components}}} {{range=@{repeating_lvl-7-spells_11_range}}} {{target=@{repeating_lvl-7-spells_11_targets}}} {{duration=@{repeating_lvl-7-spells_11_duration}}} {{saving_throw=@{repeating_lvl-7-spells_11_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_11_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_11_sr}}} {{spell_description=@{repeating_lvl-7-spells_11_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_12_Cast" title="%{selected|repeating_lvl-7-spells_12_Cast}" value="/em casts @{repeating_lvl-7-spells_12_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_12_name}}} {{school=@{repeating_lvl-7-spells_12_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_12_cast-time}}} {{components=@{repeating_lvl-7-spells_12_components}}} {{range=@{repeating_lvl-7-spells_12_range}}} {{target=@{repeating_lvl-7-spells_12_targets}}} {{duration=@{repeating_lvl-7-spells_12_duration}}} {{saving_throw=@{repeating_lvl-7-spells_12_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_12_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_12_sr}}} {{spell_description=@{repeating_lvl-7-spells_12_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_13_Cast" title="%{selected|repeating_lvl-7-spells_13_Cast}" value="/em casts @{repeating_lvl-7-spells_13_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_13_name}}} {{school=@{repeating_lvl-7-spells_13_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_13_cast-time}}} {{components=@{repeating_lvl-7-spells_13_components}}} {{range=@{repeating_lvl-7-spells_13_range}}} {{target=@{repeating_lvl-7-spells_13_targets}}} {{duration=@{repeating_lvl-7-spells_13_duration}}} {{saving_throw=@{repeating_lvl-7-spells_13_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_13_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_13_sr}}} {{spell_description=@{repeating_lvl-7-spells_13_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_14_Cast" title="%{selected|repeating_lvl-7-spells_14_Cast}" value="/em casts @{repeating_lvl-7-spells_14_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_14_name}}} {{school=@{repeating_lvl-7-spells_14_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_14_cast-time}}} {{components=@{repeating_lvl-7-spells_14_components}}} {{range=@{repeating_lvl-7-spells_14_range}}} {{target=@{repeating_lvl-7-spells_14_targets}}} {{duration=@{repeating_lvl-7-spells_14_duration}}} {{saving_throw=@{repeating_lvl-7-spells_14_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_14_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_14_sr}}} {{spell_description=@{repeating_lvl-7-spells_14_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_15_Cast" title="%{selected|repeating_lvl-7-spells_15_Cast}" value="/em casts @{repeating_lvl-7-spells_15_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_15_name}}} {{school=@{repeating_lvl-7-spells_15_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_15_cast-time}}} {{components=@{repeating_lvl-7-spells_15_components}}} {{range=@{repeating_lvl-7-spells_15_range}}} {{target=@{repeating_lvl-7-spells_15_targets}}} {{duration=@{repeating_lvl-7-spells_15_duration}}} {{saving_throw=@{repeating_lvl-7-spells_15_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_15_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_15_sr}}} {{spell_description=@{repeating_lvl-7-spells_15_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_16_Cast" title="%{selected|repeating_lvl-7-spells_16_Cast}" value="/em casts @{repeating_lvl-7-spells_16_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_16_name}}} {{school=@{repeating_lvl-7-spells_16_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_16_cast-time}}} {{components=@{repeating_lvl-7-spells_16_components}}} {{range=@{repeating_lvl-7-spells_16_range}}} {{target=@{repeating_lvl-7-spells_16_targets}}} {{duration=@{repeating_lvl-7-spells_16_duration}}} {{saving_throw=@{repeating_lvl-7-spells_16_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_16_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_16_sr}}} {{spell_description=@{repeating_lvl-7-spells_16_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_17_Cast" title="%{selected|repeating_lvl-7-spells_17_Cast}" value="/em casts @{repeating_lvl-7-spells_17_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_17_name}}} {{school=@{repeating_lvl-7-spells_17_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_17_cast-time}}} {{components=@{repeating_lvl-7-spells_17_components}}} {{range=@{repeating_lvl-7-spells_17_range}}} {{target=@{repeating_lvl-7-spells_17_targets}}} {{duration=@{repeating_lvl-7-spells_17_duration}}} {{saving_throw=@{repeating_lvl-7-spells_17_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_17_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_17_sr}}} {{spell_description=@{repeating_lvl-7-spells_17_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_18_Cast" title="%{selected|repeating_lvl-7-spells_18_Cast}" value="/em casts @{repeating_lvl-7-spells_18_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_18_name}}} {{school=@{repeating_lvl-7-spells_18_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_18_cast-time}}} {{components=@{repeating_lvl-7-spells_18_components}}} {{range=@{repeating_lvl-7-spells_18_range}}} {{target=@{repeating_lvl-7-spells_18_targets}}} {{duration=@{repeating_lvl-7-spells_18_duration}}} {{saving_throw=@{repeating_lvl-7-spells_18_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_18_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_18_sr}}} {{spell_description=@{repeating_lvl-7-spells_18_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_19_Cast" title="%{selected|repeating_lvl-7-spells_19_Cast}" value="/em casts @{repeating_lvl-7-spells_19_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_19_name}}} {{school=@{repeating_lvl-7-spells_19_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_19_cast-time}}} {{components=@{repeating_lvl-7-spells_19_components}}} {{range=@{repeating_lvl-7-spells_19_range}}} {{target=@{repeating_lvl-7-spells_19_targets}}} {{duration=@{repeating_lvl-7-spells_19_duration}}} {{saving_throw=@{repeating_lvl-7-spells_19_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_19_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_19_sr}}} {{spell_description=@{repeating_lvl-7-spells_19_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_20_Cast" title="%{selected|repeating_lvl-7-spells_20_Cast}" value="/em casts @{repeating_lvl-7-spells_20_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_20_name}}} {{school=@{repeating_lvl-7-spells_20_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_20_cast-time}}} {{components=@{repeating_lvl-7-spells_20_components}}} {{range=@{repeating_lvl-7-spells_20_range}}} {{target=@{repeating_lvl-7-spells_20_targets}}} {{duration=@{repeating_lvl-7-spells_20_duration}}} {{saving_throw=@{repeating_lvl-7-spells_20_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_20_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_20_sr}}} {{spell_description=@{repeating_lvl-7-spells_20_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_21_Cast" title="%{selected|repeating_lvl-7-spells_21_Cast}" value="/em casts @{repeating_lvl-7-spells_21_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_21_name}}} {{school=@{repeating_lvl-7-spells_21_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_21_cast-time}}} {{components=@{repeating_lvl-7-spells_21_components}}} {{range=@{repeating_lvl-7-spells_21_range}}} {{target=@{repeating_lvl-7-spells_21_targets}}} {{duration=@{repeating_lvl-7-spells_21_duration}}} {{saving_throw=@{repeating_lvl-7-spells_21_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_21_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_21_sr}}} {{spell_description=@{repeating_lvl-7-spells_21_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_22_Cast" title="%{selected|repeating_lvl-7-spells_22_Cast}" value="/em casts @{repeating_lvl-7-spells_22_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_22_name}}} {{school=@{repeating_lvl-7-spells_22_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_22_cast-time}}} {{components=@{repeating_lvl-7-spells_22_components}}} {{range=@{repeating_lvl-7-spells_22_range}}} {{target=@{repeating_lvl-7-spells_22_targets}}} {{duration=@{repeating_lvl-7-spells_22_duration}}} {{saving_throw=@{repeating_lvl-7-spells_22_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_22_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_22_sr}}} {{spell_description=@{repeating_lvl-7-spells_22_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_23_Cast" title="%{selected|repeating_lvl-7-spells_23_Cast}" value="/em casts @{repeating_lvl-7-spells_23_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_23_name}}} {{school=@{repeating_lvl-7-spells_23_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_23_cast-time}}} {{components=@{repeating_lvl-7-spells_23_components}}} {{range=@{repeating_lvl-7-spells_23_range}}} {{target=@{repeating_lvl-7-spells_23_targets}}} {{duration=@{repeating_lvl-7-spells_23_duration}}} {{saving_throw=@{repeating_lvl-7-spells_23_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_23_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_23_sr}}} {{spell_description=@{repeating_lvl-7-spells_23_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_24_Cast" title="%{selected|repeating_lvl-7-spells_24_Cast}" value="/em casts @{repeating_lvl-7-spells_24_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_24_name}}} {{school=@{repeating_lvl-7-spells_24_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_24_cast-time}}} {{components=@{repeating_lvl-7-spells_24_components}}} {{range=@{repeating_lvl-7-spells_24_range}}} {{target=@{repeating_lvl-7-spells_24_targets}}} {{duration=@{repeating_lvl-7-spells_24_duration}}} {{saving_throw=@{repeating_lvl-7-spells_24_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_24_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_24_sr}}} {{spell_description=@{repeating_lvl-7-spells_24_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_25_Cast" title="%{selected|repeating_lvl-7-spells_25_Cast}" value="/em casts @{repeating_lvl-7-spells_25_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_25_name}}} {{school=@{repeating_lvl-7-spells_25_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_25_cast-time}}} {{components=@{repeating_lvl-7-spells_25_components}}} {{range=@{repeating_lvl-7-spells_25_range}}} {{target=@{repeating_lvl-7-spells_25_targets}}} {{duration=@{repeating_lvl-7-spells_25_duration}}} {{saving_throw=@{repeating_lvl-7-spells_25_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_25_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_25_sr}}} {{spell_description=@{repeating_lvl-7-spells_25_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-7-spells_26_Cast" title="%{selected|repeating_lvl-7-spells_26_Cast}" value="/em casts @{repeating_lvl-7-spells_26_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-7-spells_26_name}}} {{school=@{repeating_lvl-7-spells_26_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-7-spells_26_cast-time}}} {{components=@{repeating_lvl-7-spells_26_components}}} {{range=@{repeating_lvl-7-spells_26_range}}} {{target=@{repeating_lvl-7-spells_26_targets}}} {{duration=@{repeating_lvl-7-spells_26_duration}}} {{saving_throw=@{repeating_lvl-7-spells_26_save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{repeating_lvl-7-spells_26_DC-mod}]]}} {{sr=@{repeating_lvl-7-spells_26_sr}}} {{spell_description=@{repeating_lvl-7-spells_26_description}}}"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-sect">
+			<div class="sheet-table">
+				<span class="sheet-table-name">Level 7 Spells</span>
+			</div>
+			<fieldset class="repeating_lvl-7-spells">
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
+                </div>
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>					
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_duration}" type="text" value="N/A" name="attr_duration" placeholder="Duration"><br>Duration</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
+					<span class="sheet-table-data sheet-center sheet-small-label">
+						<select title="@{repeating_lvl-7-spells_X_sr}" name="attr_sr">
+							<option value="" selected>Select SR</option>
+							<option value="Yes">Yes</option>
+							<option value="No">No</option>
+						</select>
+						<br>SR
+					</span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-7-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_lvl-7-spells_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-7-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-7-spells_X_macro-text}" name="attr_macro-text">/em casts @{name}!&#x00A;&{template:pf_spell} {{name=@{name}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[@{spellclass-0-level-7-savedc} + @{DC-mod}]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div> 
+	<div>
+		<b>Level 8 Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{lvl-8-spells-show}" name="attr_lvl-8-spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Level 8 Spell Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_0_Cast" title="%{selected|repeating_lvl-8-spells_0_Cast}" value="/em casts @{repeating_lvl-8-spells_0_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_0_name}}} {{school=@{repeating_lvl-8-spells_0_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_0_cast-time}}} {{components=@{repeating_lvl-8-spells_0_components}}} {{range=@{repeating_lvl-8-spells_0_range}}} {{target=@{repeating_lvl-8-spells_0_targets}}} {{duration=@{repeating_lvl-8-spells_0_duration}}} {{saving_throw=@{repeating_lvl-8-spells_0_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_0_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_0_sr}}} {{spell_description=@{repeating_lvl-8-spells_0_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_1_Cast" title="%{selected|repeating_lvl-8-spells_1_Cast}" value="/em casts @{repeating_lvl-8-spells_1_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_1_name}}} {{school=@{repeating_lvl-8-spells_1_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_1_cast-time}}} {{components=@{repeating_lvl-8-spells_1_components}}} {{range=@{repeating_lvl-8-spells_1_range}}} {{target=@{repeating_lvl-8-spells_1_targets}}} {{duration=@{repeating_lvl-8-spells_1_duration}}} {{saving_throw=@{repeating_lvl-8-spells_1_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_1_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_1_sr}}} {{spell_description=@{repeating_lvl-8-spells_1_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_2_Cast" title="%{selected|repeating_lvl-8-spells_2_Cast}" value="/em casts @{repeating_lvl-8-spells_2_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_2_name}}} {{school=@{repeating_lvl-8-spells_2_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_2_cast-time}}} {{components=@{repeating_lvl-8-spells_2_components}}} {{range=@{repeating_lvl-8-spells_2_range}}} {{target=@{repeating_lvl-8-spells_2_targets}}} {{duration=@{repeating_lvl-8-spells_2_duration}}} {{saving_throw=@{repeating_lvl-8-spells_2_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_2_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_2_sr}}} {{spell_description=@{repeating_lvl-8-spells_2_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_3_Cast" title="%{selected|repeating_lvl-8-spells_3_Cast}" value="/em casts @{repeating_lvl-8-spells_3_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_3_name}}} {{school=@{repeating_lvl-8-spells_3_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_3_cast-time}}} {{components=@{repeating_lvl-8-spells_3_components}}} {{range=@{repeating_lvl-8-spells_3_range}}} {{target=@{repeating_lvl-8-spells_3_targets}}} {{duration=@{repeating_lvl-8-spells_3_duration}}} {{saving_throw=@{repeating_lvl-8-spells_3_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_3_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_3_sr}}} {{spell_description=@{repeating_lvl-8-spells_3_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_4_Cast" title="%{selected|repeating_lvl-8-spells_4_Cast}" value="/em casts @{repeating_lvl-8-spells_4_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_4_name}}} {{school=@{repeating_lvl-8-spells_4_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_4_cast-time}}} {{components=@{repeating_lvl-8-spells_4_components}}} {{range=@{repeating_lvl-8-spells_4_range}}} {{target=@{repeating_lvl-8-spells_4_targets}}} {{duration=@{repeating_lvl-8-spells_4_duration}}} {{saving_throw=@{repeating_lvl-8-spells_4_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_4_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_4_sr}}} {{spell_description=@{repeating_lvl-8-spells_4_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_5_Cast" title="%{selected|repeating_lvl-8-spells_5_Cast}" value="/em casts @{repeating_lvl-8-spells_5_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_5_name}}} {{school=@{repeating_lvl-8-spells_5_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_5_cast-time}}} {{components=@{repeating_lvl-8-spells_5_components}}} {{range=@{repeating_lvl-8-spells_5_range}}} {{target=@{repeating_lvl-8-spells_5_targets}}} {{duration=@{repeating_lvl-8-spells_5_duration}}} {{saving_throw=@{repeating_lvl-8-spells_5_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_5_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_5_sr}}} {{spell_description=@{repeating_lvl-8-spells_5_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_6_Cast" title="%{selected|repeating_lvl-8-spells_6_Cast}" value="/em casts @{repeating_lvl-8-spells_6_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_6_name}}} {{school=@{repeating_lvl-8-spells_6_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_6_cast-time}}} {{components=@{repeating_lvl-8-spells_6_components}}} {{range=@{repeating_lvl-8-spells_6_range}}} {{target=@{repeating_lvl-8-spells_6_targets}}} {{duration=@{repeating_lvl-8-spells_6_duration}}} {{saving_throw=@{repeating_lvl-8-spells_6_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_6_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_6_sr}}} {{spell_description=@{repeating_lvl-8-spells_6_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_7_Cast" title="%{selected|repeating_lvl-8-spells_7_Cast}" value="/em casts @{repeating_lvl-8-spells_7_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_7_name}}} {{school=@{repeating_lvl-8-spells_7_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_7_cast-time}}} {{components=@{repeating_lvl-8-spells_7_components}}} {{range=@{repeating_lvl-8-spells_7_range}}} {{target=@{repeating_lvl-8-spells_7_targets}}} {{duration=@{repeating_lvl-8-spells_7_duration}}} {{saving_throw=@{repeating_lvl-8-spells_7_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_7_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_7_sr}}} {{spell_description=@{repeating_lvl-8-spells_7_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_8_Cast" title="%{selected|repeating_lvl-8-spells_8_Cast}" value="/em casts @{repeating_lvl-8-spells_8_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_8_name}}} {{school=@{repeating_lvl-8-spells_8_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_8_cast-time}}} {{components=@{repeating_lvl-8-spells_8_components}}} {{range=@{repeating_lvl-8-spells_8_range}}} {{target=@{repeating_lvl-8-spells_8_targets}}} {{duration=@{repeating_lvl-8-spells_8_duration}}} {{saving_throw=@{repeating_lvl-8-spells_8_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_8_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_8_sr}}} {{spell_description=@{repeating_lvl-8-spells_8_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_9_Cast" title="%{selected|repeating_lvl-8-spells_9_Cast}" value="/em casts @{repeating_lvl-8-spells_9_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_9_name}}} {{school=@{repeating_lvl-8-spells_9_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_9_cast-time}}} {{components=@{repeating_lvl-8-spells_9_components}}} {{range=@{repeating_lvl-8-spells_9_range}}} {{target=@{repeating_lvl-8-spells_9_targets}}} {{duration=@{repeating_lvl-8-spells_9_duration}}} {{saving_throw=@{repeating_lvl-8-spells_9_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_9_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_9_sr}}} {{spell_description=@{repeating_lvl-8-spells_9_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_10_Cast" title="%{selected|repeating_lvl-8-spells_10_Cast}" value="/em casts @{repeating_lvl-8-spells_10_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_10_name}}} {{school=@{repeating_lvl-8-spells_10_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_10_cast-time}}} {{components=@{repeating_lvl-8-spells_10_components}}} {{range=@{repeating_lvl-8-spells_10_range}}} {{target=@{repeating_lvl-8-spells_10_targets}}} {{duration=@{repeating_lvl-8-spells_10_duration}}} {{saving_throw=@{repeating_lvl-8-spells_10_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_10_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_10_sr}}} {{spell_description=@{repeating_lvl-8-spells_10_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_11_Cast" title="%{selected|repeating_lvl-8-spells_11_Cast}" value="/em casts @{repeating_lvl-8-spells_11_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_11_name}}} {{school=@{repeating_lvl-8-spells_11_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_11_cast-time}}} {{components=@{repeating_lvl-8-spells_11_components}}} {{range=@{repeating_lvl-8-spells_11_range}}} {{target=@{repeating_lvl-8-spells_11_targets}}} {{duration=@{repeating_lvl-8-spells_11_duration}}} {{saving_throw=@{repeating_lvl-8-spells_11_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_11_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_11_sr}}} {{spell_description=@{repeating_lvl-8-spells_11_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_12_Cast" title="%{selected|repeating_lvl-8-spells_12_Cast}" value="/em casts @{repeating_lvl-8-spells_12_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_12_name}}} {{school=@{repeating_lvl-8-spells_12_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_12_cast-time}}} {{components=@{repeating_lvl-8-spells_12_components}}} {{range=@{repeating_lvl-8-spells_12_range}}} {{target=@{repeating_lvl-8-spells_12_targets}}} {{duration=@{repeating_lvl-8-spells_12_duration}}} {{saving_throw=@{repeating_lvl-8-spells_12_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_12_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_12_sr}}} {{spell_description=@{repeating_lvl-8-spells_12_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_13_Cast" title="%{selected|repeating_lvl-8-spells_13_Cast}" value="/em casts @{repeating_lvl-8-spells_13_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_13_name}}} {{school=@{repeating_lvl-8-spells_13_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_13_cast-time}}} {{components=@{repeating_lvl-8-spells_13_components}}} {{range=@{repeating_lvl-8-spells_13_range}}} {{target=@{repeating_lvl-8-spells_13_targets}}} {{duration=@{repeating_lvl-8-spells_13_duration}}} {{saving_throw=@{repeating_lvl-8-spells_13_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_13_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_13_sr}}} {{spell_description=@{repeating_lvl-8-spells_13_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_14_Cast" title="%{selected|repeating_lvl-8-spells_14_Cast}" value="/em casts @{repeating_lvl-8-spells_14_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_14_name}}} {{school=@{repeating_lvl-8-spells_14_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_14_cast-time}}} {{components=@{repeating_lvl-8-spells_14_components}}} {{range=@{repeating_lvl-8-spells_14_range}}} {{target=@{repeating_lvl-8-spells_14_targets}}} {{duration=@{repeating_lvl-8-spells_14_duration}}} {{saving_throw=@{repeating_lvl-8-spells_14_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_14_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_14_sr}}} {{spell_description=@{repeating_lvl-8-spells_14_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_15_Cast" title="%{selected|repeating_lvl-8-spells_15_Cast}" value="/em casts @{repeating_lvl-8-spells_15_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_15_name}}} {{school=@{repeating_lvl-8-spells_15_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_15_cast-time}}} {{components=@{repeating_lvl-8-spells_15_components}}} {{range=@{repeating_lvl-8-spells_15_range}}} {{target=@{repeating_lvl-8-spells_15_targets}}} {{duration=@{repeating_lvl-8-spells_15_duration}}} {{saving_throw=@{repeating_lvl-8-spells_15_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_15_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_15_sr}}} {{spell_description=@{repeating_lvl-8-spells_15_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_16_Cast" title="%{selected|repeating_lvl-8-spells_16_Cast}" value="/em casts @{repeating_lvl-8-spells_16_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_16_name}}} {{school=@{repeating_lvl-8-spells_16_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_16_cast-time}}} {{components=@{repeating_lvl-8-spells_16_components}}} {{range=@{repeating_lvl-8-spells_16_range}}} {{target=@{repeating_lvl-8-spells_16_targets}}} {{duration=@{repeating_lvl-8-spells_16_duration}}} {{saving_throw=@{repeating_lvl-8-spells_16_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_16_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_16_sr}}} {{spell_description=@{repeating_lvl-8-spells_16_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_17_Cast" title="%{selected|repeating_lvl-8-spells_17_Cast}" value="/em casts @{repeating_lvl-8-spells_17_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_17_name}}} {{school=@{repeating_lvl-8-spells_17_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_17_cast-time}}} {{components=@{repeating_lvl-8-spells_17_components}}} {{range=@{repeating_lvl-8-spells_17_range}}} {{target=@{repeating_lvl-8-spells_17_targets}}} {{duration=@{repeating_lvl-8-spells_17_duration}}} {{saving_throw=@{repeating_lvl-8-spells_17_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_17_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_17_sr}}} {{spell_description=@{repeating_lvl-8-spells_17_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_18_Cast" title="%{selected|repeating_lvl-8-spells_18_Cast}" value="/em casts @{repeating_lvl-8-spells_18_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_18_name}}} {{school=@{repeating_lvl-8-spells_18_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_18_cast-time}}} {{components=@{repeating_lvl-8-spells_18_components}}} {{range=@{repeating_lvl-8-spells_18_range}}} {{target=@{repeating_lvl-8-spells_18_targets}}} {{duration=@{repeating_lvl-8-spells_18_duration}}} {{saving_throw=@{repeating_lvl-8-spells_18_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_18_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_18_sr}}} {{spell_description=@{repeating_lvl-8-spells_18_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_19_Cast" title="%{selected|repeating_lvl-8-spells_19_Cast}" value="/em casts @{repeating_lvl-8-spells_19_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_19_name}}} {{school=@{repeating_lvl-8-spells_19_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_19_cast-time}}} {{components=@{repeating_lvl-8-spells_19_components}}} {{range=@{repeating_lvl-8-spells_19_range}}} {{target=@{repeating_lvl-8-spells_19_targets}}} {{duration=@{repeating_lvl-8-spells_19_duration}}} {{saving_throw=@{repeating_lvl-8-spells_19_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_19_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_19_sr}}} {{spell_description=@{repeating_lvl-8-spells_19_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_20_Cast" title="%{selected|repeating_lvl-8-spells_20_Cast}" value="/em casts @{repeating_lvl-8-spells_20_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_20_name}}} {{school=@{repeating_lvl-8-spells_20_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_20_cast-time}}} {{components=@{repeating_lvl-8-spells_20_components}}} {{range=@{repeating_lvl-8-spells_20_range}}} {{target=@{repeating_lvl-8-spells_20_targets}}} {{duration=@{repeating_lvl-8-spells_20_duration}}} {{saving_throw=@{repeating_lvl-8-spells_20_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_20_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_20_sr}}} {{spell_description=@{repeating_lvl-8-spells_20_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_21_Cast" title="%{selected|repeating_lvl-8-spells_21_Cast}" value="/em casts @{repeating_lvl-8-spells_21_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_21_name}}} {{school=@{repeating_lvl-8-spells_21_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_21_cast-time}}} {{components=@{repeating_lvl-8-spells_21_components}}} {{range=@{repeating_lvl-8-spells_21_range}}} {{target=@{repeating_lvl-8-spells_21_targets}}} {{duration=@{repeating_lvl-8-spells_21_duration}}} {{saving_throw=@{repeating_lvl-8-spells_21_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_21_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_21_sr}}} {{spell_description=@{repeating_lvl-8-spells_21_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_22_Cast" title="%{selected|repeating_lvl-8-spells_22_Cast}" value="/em casts @{repeating_lvl-8-spells_22_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_22_name}}} {{school=@{repeating_lvl-8-spells_22_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_22_cast-time}}} {{components=@{repeating_lvl-8-spells_22_components}}} {{range=@{repeating_lvl-8-spells_22_range}}} {{target=@{repeating_lvl-8-spells_22_targets}}} {{duration=@{repeating_lvl-8-spells_22_duration}}} {{saving_throw=@{repeating_lvl-8-spells_22_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_22_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_22_sr}}} {{spell_description=@{repeating_lvl-8-spells_22_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_23_Cast" title="%{selected|repeating_lvl-8-spells_23_Cast}" value="/em casts @{repeating_lvl-8-spells_23_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_23_name}}} {{school=@{repeating_lvl-8-spells_23_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_23_cast-time}}} {{components=@{repeating_lvl-8-spells_23_components}}} {{range=@{repeating_lvl-8-spells_23_range}}} {{target=@{repeating_lvl-8-spells_23_targets}}} {{duration=@{repeating_lvl-8-spells_23_duration}}} {{saving_throw=@{repeating_lvl-8-spells_23_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_23_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_23_sr}}} {{spell_description=@{repeating_lvl-8-spells_23_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_24_Cast" title="%{selected|repeating_lvl-8-spells_24_Cast}" value="/em casts @{repeating_lvl-8-spells_24_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_24_name}}} {{school=@{repeating_lvl-8-spells_24_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_24_cast-time}}} {{components=@{repeating_lvl-8-spells_24_components}}} {{range=@{repeating_lvl-8-spells_24_range}}} {{target=@{repeating_lvl-8-spells_24_targets}}} {{duration=@{repeating_lvl-8-spells_24_duration}}} {{saving_throw=@{repeating_lvl-8-spells_24_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_24_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_24_sr}}} {{spell_description=@{repeating_lvl-8-spells_24_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_25_Cast" title="%{selected|repeating_lvl-8-spells_25_Cast}" value="/em casts @{repeating_lvl-8-spells_25_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_25_name}}} {{school=@{repeating_lvl-8-spells_25_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_25_cast-time}}} {{components=@{repeating_lvl-8-spells_25_components}}} {{range=@{repeating_lvl-8-spells_25_range}}} {{target=@{repeating_lvl-8-spells_25_targets}}} {{duration=@{repeating_lvl-8-spells_25_duration}}} {{saving_throw=@{repeating_lvl-8-spells_25_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_25_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_25_sr}}} {{spell_description=@{repeating_lvl-8-spells_25_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-8-spells_26_Cast" title="%{selected|repeating_lvl-8-spells_26_Cast}" value="/em casts @{repeating_lvl-8-spells_26_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-8-spells_26_name}}} {{school=@{repeating_lvl-8-spells_26_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-8-spells_26_cast-time}}} {{components=@{repeating_lvl-8-spells_26_components}}} {{range=@{repeating_lvl-8-spells_26_range}}} {{target=@{repeating_lvl-8-spells_26_targets}}} {{duration=@{repeating_lvl-8-spells_26_duration}}} {{saving_throw=@{repeating_lvl-8-spells_26_save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{repeating_lvl-8-spells_26_DC-mod}]]}} {{sr=@{repeating_lvl-8-spells_26_sr}}} {{spell_description=@{repeating_lvl-8-spells_26_description}}}"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-sect">
+			<div class="sheet-table">
+				<span class="sheet-table-name">Level 8 Spells</span>
+			</div>
+			<fieldset class="repeating_lvl-8-spells">
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" name="roll_Cast" value="@{macro-text}"></button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
+                </div>
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>					
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_duration}" type="text" value="N/A" name="attr_duration" placeholder="Duration"><br>Duration</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
+					<span class="sheet-table-data sheet-center sheet-small-label">
+						<select title="@{repeating_lvl-8-spells_X_sr}" name="attr_sr">
+							<option value="" selected>Select SR</option>
+							<option value="Yes">Yes</option>
+							<option value="No">No</option>
+						</select>
+						<br>SR
+					</span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-8-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_lvl-8-spells_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-8-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-8-spells_X_macro-text}" name="attr_macro-text">/em casts @{name}!&#x00A;&{template:pf_spell} {{name=@{name}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[@{spellclass-0-level-8-savedc} + @{DC-mod}]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+	<div>
+		<b>Level 9 Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{lvl-9-spells-show}" name="attr_lvl-9-spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Level 9 Spell Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_0_Cast" title="%{selected|repeating_lvl-9-spells_0_Cast}" value="/em casts @{repeating_lvl-9-spells_0_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_0_name}}} {{school=@{repeating_lvl-9-spells_0_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_0_cast-time}}} {{components=@{repeating_lvl-9-spells_0_components}}} {{range=@{repeating_lvl-9-spells_0_range}}} {{target=@{repeating_lvl-9-spells_0_targets}}} {{duration=@{repeating_lvl-9-spells_0_duration}}} {{saving_throw=@{repeating_lvl-9-spells_0_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_0_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_0_sr}}} {{spell_description=@{repeating_lvl-9-spells_0_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_1_Cast" title="%{selected|repeating_lvl-9-spells_1_Cast}" value="/em casts @{repeating_lvl-9-spells_1_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_1_name}}} {{school=@{repeating_lvl-9-spells_1_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_1_cast-time}}} {{components=@{repeating_lvl-9-spells_1_components}}} {{range=@{repeating_lvl-9-spells_1_range}}} {{target=@{repeating_lvl-9-spells_1_targets}}} {{duration=@{repeating_lvl-9-spells_1_duration}}} {{saving_throw=@{repeating_lvl-9-spells_1_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_1_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_1_sr}}} {{spell_description=@{repeating_lvl-9-spells_1_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_2_Cast" title="%{selected|repeating_lvl-9-spells_2_Cast}" value="/em casts @{repeating_lvl-9-spells_2_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_2_name}}} {{school=@{repeating_lvl-9-spells_2_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_2_cast-time}}} {{components=@{repeating_lvl-9-spells_2_components}}} {{range=@{repeating_lvl-9-spells_2_range}}} {{target=@{repeating_lvl-9-spells_2_targets}}} {{duration=@{repeating_lvl-9-spells_2_duration}}} {{saving_throw=@{repeating_lvl-9-spells_2_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_2_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_2_sr}}} {{spell_description=@{repeating_lvl-9-spells_2_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_3_Cast" title="%{selected|repeating_lvl-9-spells_3_Cast}" value="/em casts @{repeating_lvl-9-spells_3_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_3_name}}} {{school=@{repeating_lvl-9-spells_3_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_3_cast-time}}} {{components=@{repeating_lvl-9-spells_3_components}}} {{range=@{repeating_lvl-9-spells_3_range}}} {{target=@{repeating_lvl-9-spells_3_targets}}} {{duration=@{repeating_lvl-9-spells_3_duration}}} {{saving_throw=@{repeating_lvl-9-spells_3_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_3_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_3_sr}}} {{spell_description=@{repeating_lvl-9-spells_3_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_4_Cast" title="%{selected|repeating_lvl-9-spells_4_Cast}" value="/em casts @{repeating_lvl-9-spells_4_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_4_name}}} {{school=@{repeating_lvl-9-spells_4_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_4_cast-time}}} {{components=@{repeating_lvl-9-spells_4_components}}} {{range=@{repeating_lvl-9-spells_4_range}}} {{target=@{repeating_lvl-9-spells_4_targets}}} {{duration=@{repeating_lvl-9-spells_4_duration}}} {{saving_throw=@{repeating_lvl-9-spells_4_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_4_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_4_sr}}} {{spell_description=@{repeating_lvl-9-spells_4_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_5_Cast" title="%{selected|repeating_lvl-9-spells_5_Cast}" value="/em casts @{repeating_lvl-9-spells_5_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_5_name}}} {{school=@{repeating_lvl-9-spells_5_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_5_cast-time}}} {{components=@{repeating_lvl-9-spells_5_components}}} {{range=@{repeating_lvl-9-spells_5_range}}} {{target=@{repeating_lvl-9-spells_5_targets}}} {{duration=@{repeating_lvl-9-spells_5_duration}}} {{saving_throw=@{repeating_lvl-9-spells_5_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_5_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_5_sr}}} {{spell_description=@{repeating_lvl-9-spells_5_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_6_Cast" title="%{selected|repeating_lvl-9-spells_6_Cast}" value="/em casts @{repeating_lvl-9-spells_6_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_6_name}}} {{school=@{repeating_lvl-9-spells_6_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_6_cast-time}}} {{components=@{repeating_lvl-9-spells_6_components}}} {{range=@{repeating_lvl-9-spells_6_range}}} {{target=@{repeating_lvl-9-spells_6_targets}}} {{duration=@{repeating_lvl-9-spells_6_duration}}} {{saving_throw=@{repeating_lvl-9-spells_6_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_6_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_6_sr}}} {{spell_description=@{repeating_lvl-9-spells_6_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_7_Cast" title="%{selected|repeating_lvl-9-spells_7_Cast}" value="/em casts @{repeating_lvl-9-spells_7_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_7_name}}} {{school=@{repeating_lvl-9-spells_7_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_7_cast-time}}} {{components=@{repeating_lvl-9-spells_7_components}}} {{range=@{repeating_lvl-9-spells_7_range}}} {{target=@{repeating_lvl-9-spells_7_targets}}} {{duration=@{repeating_lvl-9-spells_7_duration}}} {{saving_throw=@{repeating_lvl-9-spells_7_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_7_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_7_sr}}} {{spell_description=@{repeating_lvl-9-spells_7_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_8_Cast" title="%{selected|repeating_lvl-9-spells_8_Cast}" value="/em casts @{repeating_lvl-9-spells_8_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_8_name}}} {{school=@{repeating_lvl-9-spells_8_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_8_cast-time}}} {{components=@{repeating_lvl-9-spells_8_components}}} {{range=@{repeating_lvl-9-spells_8_range}}} {{target=@{repeating_lvl-9-spells_8_targets}}} {{duration=@{repeating_lvl-9-spells_8_duration}}} {{saving_throw=@{repeating_lvl-9-spells_8_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_8_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_8_sr}}} {{spell_description=@{repeating_lvl-9-spells_8_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_9_Cast" title="%{selected|repeating_lvl-9-spells_9_Cast}" value="/em casts @{repeating_lvl-9-spells_9_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_9_name}}} {{school=@{repeating_lvl-9-spells_9_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_9_cast-time}}} {{components=@{repeating_lvl-9-spells_9_components}}} {{range=@{repeating_lvl-9-spells_9_range}}} {{target=@{repeating_lvl-9-spells_9_targets}}} {{duration=@{repeating_lvl-9-spells_9_duration}}} {{saving_throw=@{repeating_lvl-9-spells_9_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_9_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_9_sr}}} {{spell_description=@{repeating_lvl-9-spells_9_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_10_Cast" title="%{selected|repeating_lvl-9-spells_10_Cast}" value="/em casts @{repeating_lvl-9-spells_10_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_10_name}}} {{school=@{repeating_lvl-9-spells_10_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_10_cast-time}}} {{components=@{repeating_lvl-9-spells_10_components}}} {{range=@{repeating_lvl-9-spells_10_range}}} {{target=@{repeating_lvl-9-spells_10_targets}}} {{duration=@{repeating_lvl-9-spells_10_duration}}} {{saving_throw=@{repeating_lvl-9-spells_10_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_10_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_10_sr}}} {{spell_description=@{repeating_lvl-9-spells_10_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_11_Cast" title="%{selected|repeating_lvl-9-spells_11_Cast}" value="/em casts @{repeating_lvl-9-spells_11_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_11_name}}} {{school=@{repeating_lvl-9-spells_11_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_11_cast-time}}} {{components=@{repeating_lvl-9-spells_11_components}}} {{range=@{repeating_lvl-9-spells_11_range}}} {{target=@{repeating_lvl-9-spells_11_targets}}} {{duration=@{repeating_lvl-9-spells_11_duration}}} {{saving_throw=@{repeating_lvl-9-spells_11_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_11_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_11_sr}}} {{spell_description=@{repeating_lvl-9-spells_11_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_12_Cast" title="%{selected|repeating_lvl-9-spells_12_Cast}" value="/em casts @{repeating_lvl-9-spells_12_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_12_name}}} {{school=@{repeating_lvl-9-spells_12_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_12_cast-time}}} {{components=@{repeating_lvl-9-spells_12_components}}} {{range=@{repeating_lvl-9-spells_12_range}}} {{target=@{repeating_lvl-9-spells_12_targets}}} {{duration=@{repeating_lvl-9-spells_12_duration}}} {{saving_throw=@{repeating_lvl-9-spells_12_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_12_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_12_sr}}} {{spell_description=@{repeating_lvl-9-spells_12_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_13_Cast" title="%{selected|repeating_lvl-9-spells_13_Cast}" value="/em casts @{repeating_lvl-9-spells_13_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_13_name}}} {{school=@{repeating_lvl-9-spells_13_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_13_cast-time}}} {{components=@{repeating_lvl-9-spells_13_components}}} {{range=@{repeating_lvl-9-spells_13_range}}} {{target=@{repeating_lvl-9-spells_13_targets}}} {{duration=@{repeating_lvl-9-spells_13_duration}}} {{saving_throw=@{repeating_lvl-9-spells_13_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_13_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_13_sr}}} {{spell_description=@{repeating_lvl-9-spells_13_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_14_Cast" title="%{selected|repeating_lvl-9-spells_14_Cast}" value="/em casts @{repeating_lvl-9-spells_14_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_14_name}}} {{school=@{repeating_lvl-9-spells_14_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_14_cast-time}}} {{components=@{repeating_lvl-9-spells_14_components}}} {{range=@{repeating_lvl-9-spells_14_range}}} {{target=@{repeating_lvl-9-spells_14_targets}}} {{duration=@{repeating_lvl-9-spells_14_duration}}} {{saving_throw=@{repeating_lvl-9-spells_14_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_14_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_14_sr}}} {{spell_description=@{repeating_lvl-9-spells_14_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_15_Cast" title="%{selected|repeating_lvl-9-spells_15_Cast}" value="/em casts @{repeating_lvl-9-spells_15_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_15_name}}} {{school=@{repeating_lvl-9-spells_15_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_15_cast-time}}} {{components=@{repeating_lvl-9-spells_15_components}}} {{range=@{repeating_lvl-9-spells_15_range}}} {{target=@{repeating_lvl-9-spells_15_targets}}} {{duration=@{repeating_lvl-9-spells_15_duration}}} {{saving_throw=@{repeating_lvl-9-spells_15_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_15_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_15_sr}}} {{spell_description=@{repeating_lvl-9-spells_15_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_16_Cast" title="%{selected|repeating_lvl-9-spells_16_Cast}" value="/em casts @{repeating_lvl-9-spells_16_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_16_name}}} {{school=@{repeating_lvl-9-spells_16_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_16_cast-time}}} {{components=@{repeating_lvl-9-spells_16_components}}} {{range=@{repeating_lvl-9-spells_16_range}}} {{target=@{repeating_lvl-9-spells_16_targets}}} {{duration=@{repeating_lvl-9-spells_16_duration}}} {{saving_throw=@{repeating_lvl-9-spells_16_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_16_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_16_sr}}} {{spell_description=@{repeating_lvl-9-spells_16_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_17_Cast" title="%{selected|repeating_lvl-9-spells_17_Cast}" value="/em casts @{repeating_lvl-9-spells_17_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_17_name}}} {{school=@{repeating_lvl-9-spells_17_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_17_cast-time}}} {{components=@{repeating_lvl-9-spells_17_components}}} {{range=@{repeating_lvl-9-spells_17_range}}} {{target=@{repeating_lvl-9-spells_17_targets}}} {{duration=@{repeating_lvl-9-spells_17_duration}}} {{saving_throw=@{repeating_lvl-9-spells_17_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_17_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_17_sr}}} {{spell_description=@{repeating_lvl-9-spells_17_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_18_Cast" title="%{selected|repeating_lvl-9-spells_18_Cast}" value="/em casts @{repeating_lvl-9-spells_18_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_18_name}}} {{school=@{repeating_lvl-9-spells_18_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_18_cast-time}}} {{components=@{repeating_lvl-9-spells_18_components}}} {{range=@{repeating_lvl-9-spells_18_range}}} {{target=@{repeating_lvl-9-spells_18_targets}}} {{duration=@{repeating_lvl-9-spells_18_duration}}} {{saving_throw=@{repeating_lvl-9-spells_18_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_18_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_18_sr}}} {{spell_description=@{repeating_lvl-9-spells_18_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_19_Cast" title="%{selected|repeating_lvl-9-spells_19_Cast}" value="/em casts @{repeating_lvl-9-spells_19_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_19_name}}} {{school=@{repeating_lvl-9-spells_19_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_19_cast-time}}} {{components=@{repeating_lvl-9-spells_19_components}}} {{range=@{repeating_lvl-9-spells_19_range}}} {{target=@{repeating_lvl-9-spells_19_targets}}} {{duration=@{repeating_lvl-9-spells_19_duration}}} {{saving_throw=@{repeating_lvl-9-spells_19_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_19_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_19_sr}}} {{spell_description=@{repeating_lvl-9-spells_19_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_20_Cast" title="%{selected|repeating_lvl-9-spells_20_Cast}" value="/em casts @{repeating_lvl-9-spells_20_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_20_name}}} {{school=@{repeating_lvl-9-spells_20_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_20_cast-time}}} {{components=@{repeating_lvl-9-spells_20_components}}} {{range=@{repeating_lvl-9-spells_20_range}}} {{target=@{repeating_lvl-9-spells_20_targets}}} {{duration=@{repeating_lvl-9-spells_20_duration}}} {{saving_throw=@{repeating_lvl-9-spells_20_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_20_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_20_sr}}} {{spell_description=@{repeating_lvl-9-spells_20_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_21_Cast" title="%{selected|repeating_lvl-9-spells_21_Cast}" value="/em casts @{repeating_lvl-9-spells_21_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_21_name}}} {{school=@{repeating_lvl-9-spells_21_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_21_cast-time}}} {{components=@{repeating_lvl-9-spells_21_components}}} {{range=@{repeating_lvl-9-spells_21_range}}} {{target=@{repeating_lvl-9-spells_21_targets}}} {{duration=@{repeating_lvl-9-spells_21_duration}}} {{saving_throw=@{repeating_lvl-9-spells_21_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_21_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_21_sr}}} {{spell_description=@{repeating_lvl-9-spells_21_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_22_Cast" title="%{selected|repeating_lvl-9-spells_22_Cast}" value="/em casts @{repeating_lvl-9-spells_22_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_22_name}}} {{school=@{repeating_lvl-9-spells_22_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_22_cast-time}}} {{components=@{repeating_lvl-9-spells_22_components}}} {{range=@{repeating_lvl-9-spells_22_range}}} {{target=@{repeating_lvl-9-spells_22_targets}}} {{duration=@{repeating_lvl-9-spells_22_duration}}} {{saving_throw=@{repeating_lvl-9-spells_22_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_22_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_22_sr}}} {{spell_description=@{repeating_lvl-9-spells_22_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_23_Cast" title="%{selected|repeating_lvl-9-spells_23_Cast}" value="/em casts @{repeating_lvl-9-spells_23_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_23_name}}} {{school=@{repeating_lvl-9-spells_23_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_23_cast-time}}} {{components=@{repeating_lvl-9-spells_23_components}}} {{range=@{repeating_lvl-9-spells_23_range}}} {{target=@{repeating_lvl-9-spells_23_targets}}} {{duration=@{repeating_lvl-9-spells_23_duration}}} {{saving_throw=@{repeating_lvl-9-spells_23_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_23_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_23_sr}}} {{spell_description=@{repeating_lvl-9-spells_23_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_24_Cast" title="%{selected|repeating_lvl-9-spells_24_Cast}" value="/em casts @{repeating_lvl-9-spells_24_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_24_name}}} {{school=@{repeating_lvl-9-spells_24_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_24_cast-time}}} {{components=@{repeating_lvl-9-spells_24_components}}} {{range=@{repeating_lvl-9-spells_24_range}}} {{target=@{repeating_lvl-9-spells_24_targets}}} {{duration=@{repeating_lvl-9-spells_24_duration}}} {{saving_throw=@{repeating_lvl-9-spells_24_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_24_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_24_sr}}} {{spell_description=@{repeating_lvl-9-spells_24_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_25_Cast" title="%{selected|repeating_lvl-9-spells_25_Cast}" value="/em casts @{repeating_lvl-9-spells_25_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_25_name}}} {{school=@{repeating_lvl-9-spells_25_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_25_cast-time}}} {{components=@{repeating_lvl-9-spells_25_components}}} {{range=@{repeating_lvl-9-spells_25_range}}} {{target=@{repeating_lvl-9-spells_25_targets}}} {{duration=@{repeating_lvl-9-spells_25_duration}}} {{saving_throw=@{repeating_lvl-9-spells_25_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_25_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_25_sr}}} {{spell_description=@{repeating_lvl-9-spells_25_description}}}"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-9-spells_26_Cast" title="%{selected|repeating_lvl-9-spells_26_Cast}" value="/em casts @{repeating_lvl-9-spells_26_name}!&#x00A;&{template:pf_spell} {{name=@{repeating_lvl-9-spells_26_name}}} {{school=@{repeating_lvl-9-spells_26_school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{repeating_lvl-9-spells_26_cast-time}}} {{components=@{repeating_lvl-9-spells_26_components}}} {{range=@{repeating_lvl-9-spells_26_range}}} {{target=@{repeating_lvl-9-spells_26_targets}}} {{duration=@{repeating_lvl-9-spells_26_duration}}} {{saving_throw=@{repeating_lvl-9-spells_26_save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{repeating_lvl-9-spells_26_DC-mod}]]}} {{sr=@{repeating_lvl-9-spells_26_sr}}} {{spell_description=@{repeating_lvl-9-spells_26_description}}}"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-sect">
+			<div class="sheet-table">
+				<span class="sheet-table-name">Level 9 Spells</span>
+			</div>
+			<fieldset class="repeating_lvl-9-spells">
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
+                </div>
+				<div class="sheet-table">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>					
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_duration}" type="text" value="N/A" name="attr_duration" placeholder="Duration"><br>Duration</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
+					<span class="sheet-table-data sheet-center sheet-small-label">
+						<select title="@{repeating_lvl-9-spells_X_sr}" name="attr_sr">
+							<option value="" selected>Select SR</option>
+							<option value="Yes">Yes</option>
+							<option value="No">No</option>
+						</select>
+						<br>SR
+					</span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-9-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_lvl-9-spells_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-9-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-9-spells_X_macro-text}" name="attr_macro-text">/em casts @{name}!&#x00A;&{template:pf_spell} {{name=@{name}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[@{spellclass-0-level-total}]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[@{spellclass-0-level-9-savedc} + @{DC-mod}]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+</div>
+<div class="sheet-section sheet-section-details">
+	<div>
+		<b>Character Details&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{character-details-show}" name="attr_character-details-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">  
+			<span class="sheet-table-name">Character Details</span> 
+		</div>
+		<div class="sheet-sect">    
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:25%;"><input title="@{character_name}" type="text" name="attr_character_name" placeholder="Character Name"/><br>Character Name</span>
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><input title="@{player-name}" type="text" name="attr_player-name" placeholder="Player Name"/><br>Player Name</span>	
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><input title="@{race}" type="text" name="attr_race" placeholder="Race"/><br>Race</span>  		
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input title="@{gender}" type="text" name="attr_gender" placeholder="Gender"/><br>Gender</span>  		
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input title="@{alignment}" type="text" name="attr_alignment" placeholder="Alignment"/><br>Alignment</span>  	
+		</div>
+		<div class="sheet-sect">		
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;">
+				<select title="@{size}" name="attr_size">
+					<option value="-8">Colossal</option>
+					<option value="-4">Gargantuan</option>
+					<option value="-2">Huge</option>
+					<option value="-1">Large</option>
+					<option value="0" selected>Medium</option>
+					<option value="1">Small</option>
+					<option value="2">Tiny</option>
+					<option value="4">Diminutive</option>
+					<option value="8">Fine</option>
+				</select>
+				<br>Size
+			</span>
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:8%;"><input title="@{height}" type="text" name="attr_height" placeholder="Height"/><br>Height</span>
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:8%;"><input title="@{weight}" type="text" name="attr_weight" placeholder="Weight"/><br>Weight</span>
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:25%;"><input title="@{hair}" type="text" name="attr_hair" placeholder="Hair Details"/><br>Hair</span>
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:25%;"><input title="@{eyes}" type="text" name="attr_eyes" placeholder="Eyes Details"/><br>Eyes</span>
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:25%;"><input title="@{skin}" type="text" name="attr_skin" placeholder="Skin Details"/><br>Skin</span>
+		</div>
+		<div class="sheet-sect">	
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:8%;"><input style="width:100%;" title="@{age}" type="number" name="attr_age" placeholder="Age"/><br>Age</span>
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:30%;"><input title="@{deity}" type="text" name="attr_deity" placeholder="Deity"/><br>Deity</span>
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:30%;"><input title="@{homeland}" type="text" name="attr_homeland" placeholder="Homeland"/><br>Homeland</span>
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:30%;"><input title="@{occupation}" type="text" name="attr_occupation" placeholder="Occupation"/><br>Occupation</span>
+		</div>
+		<div class="sheet-sect" style="width:100%;">				
+			<input title="@{languages}" type="text" name="attr_languages" placeholder="Languages"/>
+			<div class="sheet-center sheet-small-label">Languages</div>
+		</div>
+		<br>
+	</div>
+	<div>
+		<b>Racial Traits&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{racial-traits-show}" name="attr_racial-traits-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Racial Trait Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_0_Display" title="%{selected|repeating_racial-trait_0_Display}" value="/em is activating their @{repeating_racial-trait_0_name} racial trait&#x00A;@{repeating_racial-trait_0_short-description}&#x00A;@{repeating_racial-trait_0_name} uses remaining: [[@{repeating_racial-trait_0_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_1_Display" title="%{selected|repeating_racial-trait_1_Display}" value="/em is activating their @{repeating_racial-trait_1_name} racial trait&#x00A;@{repeating_racial-trait_1_short-description}&#x00A;@{repeating_racial-trait_1_name} uses remaining: [[@{repeating_racial-trait_1_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_2_Display" title="%{selected|repeating_racial-trait_2_Display}" value="/em is activating their @{repeating_racial-trait_2_name} racial trait&#x00A;@{repeating_racial-trait_2_short-description}&#x00A;@{repeating_racial-trait_2_name} uses remaining: [[@{repeating_racial-trait_2_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_3_Display" title="%{selected|repeating_racial-trait_3_Display}" value="/em is activating their @{repeating_racial-trait_3_name} racial trait&#x00A;@{repeating_racial-trait_3_short-description}&#x00A;@{repeating_racial-trait_3_name} uses remaining: [[@{repeating_racial-trait_3_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_4_Display" title="%{selected|repeating_racial-trait_4_Display}" value="/em is activating their @{repeating_racial-trait_4_name} racial trait&#x00A;@{repeating_racial-trait_4_short-description}&#x00A;@{repeating_racial-trait_4_name} uses remaining: [[@{repeating_racial-trait_4_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_5_Display" title="%{selected|repeating_racial-trait_5_Display}" value="/em is activating their @{repeating_racial-trait_5_name} racial trait&#x00A;@{repeating_racial-trait_5_short-description}&#x00A;@{repeating_racial-trait_5_name} uses remaining: [[@{repeating_racial-trait_5_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_6_Display" title="%{selected|repeating_racial-trait_6_Display}" value="/em is activating their @{repeating_racial-trait_6_name} racial trait&#x00A;@{repeating_racial-trait_6_short-description}&#x00A;@{repeating_racial-trait_6_name} uses remaining: [[@{repeating_racial-trait_6_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_7_Display" title="%{selected|repeating_racial-trait_7_Display}" value="/em is activating their @{repeating_racial-trait_7_name} racial trait&#x00A;@{repeating_racial-trait_7_short-description}&#x00A;@{repeating_racial-trait_7_name} uses remaining: [[@{repeating_racial-trait_7_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_8_Display" title="%{selected|repeating_racial-trait_8_Display}" value="/em is activating their @{repeating_racial-trait_8_name} racial trait&#x00A;@{repeating_racial-trait_8_short-description}&#x00A;@{repeating_racial-trait_8_name} uses remaining: [[@{repeating_racial-trait_8_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_9_Display" title="%{selected|repeating_racial-trait_9_Display}" value="/em is activating their @{repeating_racial-trait_9_name} racial trait&#x00A;@{repeating_racial-trait_9_short-description}&#x00A;@{repeating_racial-trait_9_name} uses remaining: [[@{repeating_racial-trait_9_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_10_Display" title="%{selected|repeating_racial-trait_10_Display}" value="/em is activating their @{repeating_racial-trait_10_name} racial trait&#x00A;@{repeating_racial-trait_10_short-description}&#x00A;@{repeating_racial-trait_10_name} uses remaining: [[@{repeating_racial-trait_10_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_11_Display" title="%{selected|repeating_racial-trait_11_Display}" value="/em is activating their @{repeating_racial-trait_11_name} racial trait&#x00A;@{repeating_racial-trait_11_short-description}&#x00A;@{repeating_racial-trait_11_name} uses remaining: [[@{repeating_racial-trait_11_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_12_Display" title="%{selected|repeating_racial-trait_12_Display}" value="/em is activating their @{repeating_racial-trait_12_name} racial trait&#x00A;@{repeating_racial-trait_12_short-description}&#x00A;@{repeating_racial-trait_12_name} uses remaining: [[@{repeating_racial-trait_12_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_13_Display" title="%{selected|repeating_racial-trait_13_Display}" value="/em is activating their @{repeating_racial-trait_13_name} racial trait&#x00A;@{repeating_racial-trait_13_short-description}&#x00A;@{repeating_racial-trait_13_name} uses remaining: [[@{repeating_racial-trait_13_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_14_Display" title="%{selected|repeating_racial-trait_14_Display}" value="/em is activating their @{repeating_racial-trait_14_name} racial trait&#x00A;@{repeating_racial-trait_14_short-description}&#x00A;@{repeating_racial-trait_14_name} uses remaining: [[@{repeating_racial-trait_14_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_15_Display" title="%{selected|repeating_racial-trait_15_Display}" value="/em is activating their @{repeating_racial-trait_15_name} racial trait&#x00A;@{repeating_racial-trait_15_short-description}&#x00A;@{repeating_racial-trait_15_name} uses remaining: [[@{repeating_racial-trait_15_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_16_Display" title="%{selected|repeating_racial-trait_16_Display}" value="/em is activating their @{repeating_racial-trait_16_name} racial trait&#x00A;@{repeating_racial-trait_16_short-description}&#x00A;@{repeating_racial-trait_16_name} uses remaining: [[@{repeating_racial-trait_16_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_17_Display" title="%{selected|repeating_racial-trait_17_Display}" value="/em is activating their @{repeating_racial-trait_17_name} racial trait&#x00A;@{repeating_racial-trait_17_short-description}&#x00A;@{repeating_racial-trait_17_name} uses remaining: [[@{repeating_racial-trait_17_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_18_Display" title="%{selected|repeating_racial-trait_18_Display}" value="/em is activating their @{repeating_racial-trait_18_name} racial trait&#x00A;@{repeating_racial-trait_18_short-description}&#x00A;@{repeating_racial-trait_18_name} uses remaining: [[@{repeating_racial-trait_18_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_19_Display" title="%{selected|repeating_racial-trait_19_Display}" value="/em is activating their @{repeating_racial-trait_19_name} racial trait&#x00A;@{repeating_racial-trait_19_short-description}&#x00A;@{repeating_racial-trait_19_name} uses remaining: [[@{repeating_racial-trait_19_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_20_Display" title="%{selected|repeating_racial-trait_20_Display}" value="/em is activating their @{repeating_racial-trait_20_name} racial trait&#x00A;@{repeating_racial-trait_20_short-description}&#x00A;@{repeating_racial-trait_20_name} uses remaining: [[@{repeating_racial-trait_20_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_21_Display" title="%{selected|repeating_racial-trait_21_Display}" value="/em is activating their @{repeating_racial-trait_21_name} racial trait&#x00A;@{repeating_racial-trait_21_short-description}&#x00A;@{repeating_racial-trait_21_name} uses remaining: [[@{repeating_racial-trait_21_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_22_Display" title="%{selected|repeating_racial-trait_22_Display}" value="/em is activating their @{repeating_racial-trait_22_name} racial trait&#x00A;@{repeating_racial-trait_22_short-description}&#x00A;@{repeating_racial-trait_22_name} uses remaining: [[@{repeating_racial-trait_22_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_23_Display" title="%{selected|repeating_racial-trait_23_Display}" value="/em is activating their @{repeating_racial-trait_23_name} racial trait&#x00A;@{repeating_racial-trait_23_short-description}&#x00A;@{repeating_racial-trait_23_name} uses remaining: [[@{repeating_racial-trait_23_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_24_Display" title="%{selected|repeating_racial-trait_24_Display}" value="/em is activating their @{repeating_racial-trait_24_name} racial trait&#x00A;@{repeating_racial-trait_24_short-description}&#x00A;@{repeating_racial-trait_24_name} uses remaining: [[@{repeating_racial-trait_24_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_25_Display" title="%{selected|repeating_racial-trait_25_Display}" value="/em is activating their @{repeating_racial-trait_25_name} racial trait&#x00A;@{repeating_racial-trait_25_short-description}&#x00A;@{repeating_racial-trait_25_name} uses remaining: [[@{repeating_racial-trait_25_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_racial-trait_26_Display" title="%{selected|repeating_racial-trait_26_Display}" value="/em is activating their @{repeating_racial-trait_26_name} racial trait&#x00A;@{repeating_racial-trait_26_short-description}&#x00A;@{repeating_racial-trait_26_name} uses remaining: [[@{repeating_racial-trait_26_used}-1]]"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Racial Traits</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header" style="width:5%;"></span>
+				<span class="sheet-table-header" style="width:15%;">Name</span>
+				<span class="sheet-table-header" style="width:53%;">Short Description</span>
+				<span class="sheet-table-header" style="width:5%;">Uses</span>
+				<span class="sheet-table-header" style="width:2%;vertical-align:bottom;font-size:150%;">/</span>
+				<span class="sheet-table-header" style="width:5%;">Max</span>
+				<span class="sheet-table-header" style="width:15%;">Max Calculation</span>
+			</div>
+		</div>
+		<div class="sheet-table sheet-sect">
+			<fieldset class="repeating_racial-trait">
+				<div class="sheet-table-row">
+					<span class="sheet-table-data sheet-center" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+					<span class="sheet-table-data sheet-center" style="width:15%;"><input title="@{repeating_racial-trait_X_name}" type="text" name="attr_name" placeholder="Racial Trait Name"></span>
+					<span class="sheet-table-data sheet-center" style="width:28%;"><input title="@{repeating_racial-trait_X_short-description}" type="text" name="attr_short-description" placeholder="Short Description"></span>
+					<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_racial-trait_X_used}" type="number" name="attr_used" value="0"></span>
+					<span class="sheet-table-data sheet-center" style="width:2%;vertical-align:middle;font-size:150%;">/</span>
+					<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_racial-trait_X_used|max" type="number" name="attr_used_max" value="@{max-calculation}" disabled></span>
+					<span class="sheet-table-data sheet-center" style="width:15%;"><input title="@{repeating_racial-trait_X_max-calculation}" type="text" name="attr_max-calculation" value="0"></span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_racial-trait_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_racial-trait_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_racial-trait_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_racial-trait_X_macro-text}" name="attr_macro-text">/em is activating their @{name} racial trait&#x00A;@{short-description}&#x00A;@{name} uses remaining: [[@{used}-1]]</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+	<div>
+		<b>Traits&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{traits-show}" name="attr_traits-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Trait Buttons</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">0</span>
+				<span class="sheet-table-header">1</span>
+				<span class="sheet-table-header">2</span>
+				<span class="sheet-table-header">3</span>
+				<span class="sheet-table-header">4</span>
+				<span class="sheet-table-header">5</span>
+				<span class="sheet-table-header">6</span>
+				<span class="sheet-table-header">7</span>
+				<span class="sheet-table-header">8</span>
+				<span class="sheet-table-header">9</span>
+				<span class="sheet-table-header">10</span>
+				<span class="sheet-table-header">11</span>
+				<span class="sheet-table-header">12</span>
+				<span class="sheet-table-header">13</span>
+				<span class="sheet-table-header">14</span>
+				<span class="sheet-table-header">15</span>
+				<span class="sheet-table-header">16</span>
+				<span class="sheet-table-header">17</span>
+				<span class="sheet-table-header">18</span>
+				<span class="sheet-table-header">19</span>
+				<span class="sheet-table-header">20</span>
+				<span class="sheet-table-header">21</span>
+				<span class="sheet-table-header">22</span>
+				<span class="sheet-table-header">23</span>
+				<span class="sheet-table-header">24</span>
+				<span class="sheet-table-header">25</span>
+				<span class="sheet-table-header">26</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_0_Display" title="%{selected|repeating_trait_0_Display}" value="/em is activating their @{repeating_trait_0_name} trait&#x00A;@{repeating_trait_0_short-description}&#x00A;@{repeating_trait_0_name} uses remaining: [[@{repeating_trait_0_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_1_Display" title="%{selected|repeating_trait_1_Display}" value="/em is activating their @{repeating_trait_1_name} trait&#x00A;@{repeating_trait_1_short-description}&#x00A;@{repeating_trait_1_name} uses remaining: [[@{repeating_trait_1_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_2_Display" title="%{selected|repeating_trait_2_Display}" value="/em is activating their @{repeating_trait_2_name} trait&#x00A;@{repeating_trait_2_short-description}&#x00A;@{repeating_trait_2_name} uses remaining: [[@{repeating_trait_2_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_3_Display" title="%{selected|repeating_trait_3_Display}" value="/em is activating their @{repeating_trait_3_name} trait&#x00A;@{repeating_trait_3_short-description}&#x00A;@{repeating_trait_3_name} uses remaining: [[@{repeating_trait_3_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_4_Display" title="%{selected|repeating_trait_4_Display}" value="/em is activating their @{repeating_trait_4_name} trait&#x00A;@{repeating_trait_4_short-description}&#x00A;@{repeating_trait_4_name} uses remaining: [[@{repeating_trait_4_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_5_Display" title="%{selected|repeating_trait_5_Display}" value="/em is activating their @{repeating_trait_5_name} trait&#x00A;@{repeating_trait_5_short-description}&#x00A;@{repeating_trait_5_name} uses remaining: [[@{repeating_trait_5_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_6_Display" title="%{selected|repeating_trait_6_Display}" value="/em is activating their @{repeating_trait_6_name} trait&#x00A;@{repeating_trait_6_short-description}&#x00A;@{repeating_trait_6_name} uses remaining: [[@{repeating_trait_6_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_7_Display" title="%{selected|repeating_trait_7_Display}" value="/em is activating their @{repeating_trait_7_name} trait&#x00A;@{repeating_trait_7_short-description}&#x00A;@{repeating_trait_7_name} uses remaining: [[@{repeating_trait_7_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_8_Display" title="%{selected|repeating_trait_8_Display}" value="/em is activating their @{repeating_trait_8_name} trait&#x00A;@{repeating_trait_8_short-description}&#x00A;@{repeating_trait_8_name} uses remaining: [[@{repeating_trait_8_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_9_Display" title="%{selected|repeating_trait_9_Display}" value="/em is activating their @{repeating_trait_9_name} trait&#x00A;@{repeating_trait_9_short-description}&#x00A;@{repeating_trait_9_name} uses remaining: [[@{repeating_trait_9_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_10_Display" title="%{selected|repeating_trait_10_Display}" value="/em is activating their @{repeating_trait_10_name} trait&#x00A;@{repeating_trait_10_short-description}&#x00A;@{repeating_trait_10_name} uses remaining: [[@{repeating_trait_10_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_11_Display" title="%{selected|repeating_trait_11_Display}" value="/em is activating their @{repeating_trait_11_name} trait&#x00A;@{repeating_trait_11_short-description}&#x00A;@{repeating_trait_11_name} uses remaining: [[@{repeating_trait_11_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_12_Display" title="%{selected|repeating_trait_12_Display}" value="/em is activating their @{repeating_trait_12_name} trait&#x00A;@{repeating_trait_12_short-description}&#x00A;@{repeating_trait_12_name} uses remaining: [[@{repeating_trait_12_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_13_Display" title="%{selected|repeating_trait_13_Display}" value="/em is activating their @{repeating_trait_13_name} trait&#x00A;@{repeating_trait_13_short-description}&#x00A;@{repeating_trait_13_name} uses remaining: [[@{repeating_trait_13_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_14_Display" title="%{selected|repeating_trait_14_Display}" value="/em is activating their @{repeating_trait_14_name} trait&#x00A;@{repeating_trait_14_short-description}&#x00A;@{repeating_trait_14_name} uses remaining: [[@{repeating_trait_14_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_15_Display" title="%{selected|repeating_trait_15_Display}" value="/em is activating their @{repeating_trait_15_name} trait&#x00A;@{repeating_trait_15_short-description}&#x00A;@{repeating_trait_15_name} uses remaining: [[@{repeating_trait_15_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_16_Display" title="%{selected|repeating_trait_16_Display}" value="/em is activating their @{repeating_trait_16_name} trait&#x00A;@{repeating_trait_16_short-description}&#x00A;@{repeating_trait_16_name} uses remaining: [[@{repeating_trait_16_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_17_Display" title="%{selected|repeating_trait_17_Display}" value="/em is activating their @{repeating_trait_17_name} trait&#x00A;@{repeating_trait_17_short-description}&#x00A;@{repeating_trait_17_name} uses remaining: [[@{repeating_trait_17_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_18_Display" title="%{selected|repeating_trait_18_Display}" value="/em is activating their @{repeating_trait_18_name} trait&#x00A;@{repeating_trait_18_short-description}&#x00A;@{repeating_trait_18_name} uses remaining: [[@{repeating_trait_18_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_19_Display" title="%{selected|repeating_trait_19_Display}" value="/em is activating their @{repeating_trait_19_name} trait&#x00A;@{repeating_trait_19_short-description}&#x00A;@{repeating_trait_19_name} uses remaining: [[@{repeating_trait_19_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_20_Display" title="%{selected|repeating_trait_20_Display}" value="/em is activating their @{repeating_trait_20_name} trait&#x00A;@{repeating_trait_20_short-description}&#x00A;@{repeating_trait_20_name} uses remaining: [[@{repeating_trait_20_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_21_Display" title="%{selected|repeating_trait_21_Display}" value="/em is activating their @{repeating_trait_21_name} trait&#x00A;@{repeating_trait_21_short-description}&#x00A;@{repeating_trait_21_name} uses remaining: [[@{repeating_trait_21_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_22_Display" title="%{selected|repeating_trait_22_Display}" value="/em is activating their @{repeating_trait_22_name} trait&#x00A;@{repeating_trait_22_short-description}&#x00A;@{repeating_trait_22_name} uses remaining: [[@{repeating_trait_22_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_23_Display" title="%{selected|repeating_trait_23_Display}" value="/em is activating their @{repeating_trait_23_name} trait&#x00A;@{repeating_trait_23_short-description}&#x00A;@{repeating_trait_23_name} uses remaining: [[@{repeating_trait_23_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_24_Display" title="%{selected|repeating_trait_24_Display}" value="/em is activating their @{repeating_trait_24_name} trait&#x00A;@{repeating_trait_24_short-description}&#x00A;@{repeating_trait_24_name} uses remaining: [[@{repeating_trait_24_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_25_Display" title="%{selected|repeating_trait_25_Display}" value="/em is activating their @{repeating_trait_25_name} trait&#x00A;@{repeating_trait_25_short-description}&#x00A;@{repeating_trait_25_name} uses remaining: [[@{repeating_trait_25_used}-1]]"></button></span>
+				<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_trait_26_Display" title="%{selected|repeating_trait_26_Display}" value="/em is activating their @{repeating_trait_26_name} trait&#x00A;@{repeating_trait_26_short-description}&#x00A;@{repeating_trait_26_name} uses remaining: [[@{repeating_trait_26_used}-1]]"></button></span>
+			</div>
+		</div>
+		<br>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Traits</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header" style="width:5%;"></span>
+				<span class="sheet-table-header" style="width:15%;">Name</span>
+				<span class="sheet-table-header" style="width:53%;">Short Description</span>
+				<span class="sheet-table-header" style="width:5%;">Uses</span>
+				<span class="sheet-table-header" style="width:2%;vertical-align:bottom;font-size:150%;">/</span>
+				<span class="sheet-table-header" style="width:5%;">Max</span>
+				<span class="sheet-table-header" style="width:15%;">Max Calculation</span>
+			</div>
+		</div>
+		<div class="sheet-table sheet-sect">
+			<fieldset class="repeating_trait">
+				<div class="sheet-table-row">
+					<span class="sheet-table-data sheet-center" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+					<span class="sheet-table-data sheet-center" style="width:15%;"><input title="@{repeating_trait_X_name}" type="text" name="attr_name" placeholder="Trait Name"></span>
+					<span class="sheet-table-data sheet-center" style="width:28%;"><input title="@{repeating_trait_X_short-description}" type="text" name="attr_short-description" placeholder="Short Description"></span>
+					<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_trait_X_used}" type="number" name="attr_used" value="0"></span>
+					<span class="sheet-table-data sheet-center" style="width:2%;vertical-align:middle;font-size:150%;">/</span>
+					<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_trait_X_used|max" type="number" name="attr_used_max" value="@{max-calculation}" disabled></span>
+					<span class="sheet-table-data sheet-center" style="width:15%;"><input title="@{repeating_trait_X_max-calculation}" type="text" name="attr_max-calculation" value="0"></span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_trait_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_trait_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_trait_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_trait_X_macro-text}" name="attr_macro-text">/em is activating their @{name} trait&#x00A;@{short-description}&#x00A;@{name} uses remaining: [[@{used}-1]]</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+</div>
+<div class="sheet-npc sheet-section-npc">
+    <div class="sheet-table" style="width:100%;background-color:black;color:white;padding-left:10px;">  
+        <span class="sheet-table-data sheet-center" style="width:90%;text-align:left;"><input type="text" title="character_name" name="attr_character_name" style="background-color:black;color:white;font-weight:bold;border:1px dotted #FFFFFF"/></span> 		
+		<span class="sheet-table-data sheet-right" style="width:5%;text-align:right;"><b>CR</b></span>
+		<span class="sheet-table-data sheet-right" style="width:5%;text-align:right;"><input type="text" title="npc-cr" name="attr_npc-cr" style="background-color:black;color:white;font-weight:bold;border:1px dotted #FFFFFF"/></span> 
+	</div>
+	<br>
+	<div class="sheet-center">
+		<div style="width:10%;">
+			<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;"><input type="text" name="attr_npc-xp" title="@{npc-xp}" placeholder="XP"><br>XP</span>
+		</div>
+		<br>
+		<div class="sheet-table">
+			<div class="sheet-table-row">
+				<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;"><input title="@{gender}" type="text" name="attr_gender" placeholder="Gender"/><br>Gender</span> 
+				<span class="sheet-table-data sheet-center sheet-small-label" style="width:25%;"><input title="@{race}" type="text" name="attr_race" placeholder="Race"/><br>Race</span> 
+				<span class="sheet-table-data sheet-center sheet-small-label" style="width:65%;"><input title="@{class-0-name}" type="text" name="attr_class-0-name" placeholder="Class(es)"/><br>Class(es)</span> 
+			</div>
+		</div>
+		<div class="sheet-table">
+			<div class="sheet-table-row">				
+				<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input title="@{alignment}" type="text" name="attr_alignment" placeholder="Alignment"/><br>Alignment</span>  	
+				<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;">
+					<select title="@{size}" name="attr_size">
+						<option value="-8">Colossal</option>
+						<option value="-4">Gargantuan</option>
+						<option value="-2">Huge</option>
+						<option value="-1">Large</option>
+						<option value="0" selected>Medium</option>
+						<option value="1">Small</option>
+						<option value="2">Tiny</option>
+						<option value="4">Diminutive</option>
+						<option value="8">Fine</option>
+					</select>
+					<br>Size
+				</span>
+				<span class="sheet-table-data sheet-center sheet-small-label" style="width:70%;"><input title="@{npc-type}" type="text" name="attr_npc-type" placeholder="Type (sub-type)"/><br>Type (sub-type)</span>  	
+			</div>
+		</div>
+		<div class="sheet-table">
+			<div class="sheet-table-row">				
+				<span class="sheet-table-data sheet-center" style="width:5%;"><button title="%{selected|NPC-Initiative-Roll}" type="roll" name="roll_NPC-Initiative-Roll" value="/w gm @{character_name}'s Initiative result: [[((1d20 + @{init}) + (0.01 * @{init})) &amp;{tracker}]]">Initiative</button></span>
+				<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" title="@{init}" name="attr_init" value="(@{DEX-mod} + @{init-misc} + @{init-trait})" disabled><br>Total</span>
+				<span class="sheet-table-data sheet-center sheet-small-label">=<br>&nbsp;</span>
+				<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" title="@{DEX-mod}" name="attr_init-DEX" value="@{DEX-mod}" disabled><br>DEX</span>
+				<span class="sheet-table-data sheet-center sheet-small-label">+<br>&nbsp;</span>
+				<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" title="@{init-misc}" name="attr_init-misc" value="0" min="0"><br>Misc</span>
+				<span class="sheet-table-data sheet-center sheet-small-label" style="width:80%;"><input type="text" title="@{npc-senses}" name="attr_npc-senses" placeholder="Senses"/><br>Senses</span>
+			</div>
+		</div>
+		<div class="sheet-table">
+			<div class="sheet-table-row">				
+				<span class="sheet-table-data sheet-center sheet-small-label" style="width:80%;"><input type="text" title="@{npc-aura}" name="attr_npc-aura" placeholder="Aura"/><br>Aura</span>
+			</div>
+		</div>
+	</div>	
+	<div>
+		<hr/>
+		<b>DEFENSE&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{npc-defense-show}" name="attr_npc-defense-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<hr/>
+		<div style="text-align:left;" class="sheet-sect">
+			<div class="sheet-table">
+				<div class="sheet-table-row">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input type="number" title="@{AC}" name="attr_AC" value="(10 + @{AC-armor} + @{AC-shield} + @{AC-DEX} + @{size} + @{AC-dodge} + @{AC-natural} + @{AC-deflect} + @{AC-misc} + @{AC-temp} + @{AC-penalty})" disabled><br>AC</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{Touch}" type="number" name="attr_Touch" value="(10 + @{AC-DEX} + @{size} + @{AC-dodge} + @{AC-deflect} + @{AC-misc} + @{AC-temp} + @{AC-penalty})" disabled><br>Touch</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{Flat-Footed}" type="number" name="attr_Flat-Footed" value="(10 + @{AC-armor} + @{AC-shield} + @{FF-DEX} + @{size} + @{AC-natural} + @{AC-deflect} + @{AC-misc} + @{AC-temp} + @{AC-penalty})" disabled><br>Flat-Footed</span>
+					<span class="sheet-table-data sheet-center sheet-small-label">|<br>|</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{armor-acbonus}" type="number" name="attr_armor-acbonus" value="0"><br>Armor</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{shield-acbonus}" type="number" name="attr_shield-acbonus" value="0"><br>Shield</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{AC-deflect}" type="number" name="attr_AC-deflect" value="0"><br>Deflect</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{AC-DEX}" type="number" name="attr_AC-DEX" value="(((@{DEX-mod} + @{max-dex-source}) - abs(@{DEX-mod} - @{max-dex-source})) / 2)" disabled><br>DEX</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{AC-dodge}" type="number" name="attr_AC-dodge" value="0"><br>Dodge</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{AC-natural}" type="number" name="attr_AC-natural" value="0"><br>Natural</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{size}" type="number" name="attr_AC-size" value="@{size}" disabled><br>Size</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{AC-misc}" type="number" name="attr_AC-misc" value="0"><br>Misc</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{AC-temp}" type="number" name="attr_AC-temp" value="0"><br>Temp</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{AC-penalty}" type="number" name="attr_AC-penalty" value="0" max="0"><br>Penalty</span>
+				</div>
+			</div>
+			<div class="sheet-table">
+				<div class="sheet-table-row">				
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" title="@{NPC-HP}" name="attr_NPC-HP" value="0"><br>HP</span>
+					<span class="sheet-table-data sheet-center" style="width:5%;vertical-align:middle;font-size:150%;"><b>/</b><br>&nbsp;</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" title="@{NPC-HP|max}" name="attr_NPC-HP_max" value="@{NPC-HP-formula}" disabled><br>Max</span>
+					<span class="sheet-table-data sheet-right" style="width:5%;vertical-align:middle;font-size:150%;"><b>(</b><br>&nbsp;</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{NPC-HD-num}" type="number" name="attr_npc-hd-num" value="0"><br>&nbsp;</span>
+					<span class="sheet-table-data sheet-center" style="width:5%;vertical-align:middle;font-size:150%;"><b>d</b><br>&nbsp;</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{NPC-HD}" type="number" name="attr_npc-hd" value="0"><br>&nbsp;</span>
+					<span class="sheet-table-data sheet-center" style="width:5%;vertical-align:middle;font-size:150%;"><b>+</b><br>&nbsp;</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{NPC-HD-misc}" type="number" name="attr_npc-hd-misc" value="0"><br>&nbsp;</span>
+					<span class="sheet-table-data sheet-center" style="width:5%;vertical-align:middle;font-size:150%;"><b>)</b><br>&nbsp;</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" title="@{HP-temp}" name="attr_HP-temp" value="0" min="0"><br>Temp</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" title="@{non-lethal-damage}" name="attr_non-lethal-damage" value="0" min="0"><br>NL</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><input title="@{NPC-HP-formula}" type="text" name="attr_NPC-HP-formula" value="(floor(((@{npc-hd}+1)/2) * @{npc-hd-num}) + @{npc-hd-misc})"><br>NPC HP Formula</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="text-align:left;width:20%;"><input type="text" title="@{npc-heal-conditions}" name="attr_npc-heal-conditions" placeholder="Heal conditions"><br>Heal Conditions</span>
+				</div>
+			</div>
+			<div class="sheet-table">
+				<div class="sheet-table-row">	
+					<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Fort-Save}" type="roll" name="roll_NPC-Fort-Save" value="/w gm @{character_name}'s Fort save: [[1d20 + @{Fort}]]&#x00A;/w gm Save notes: @{save-notes}">Fort</button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{Fort}" type="number" name="attr_Fort" value="(@{total-Fort} + @{CON-mod} + @{Fort-trait} + @{Fort-enhance} + @{Fort-resist} + @{Fort-misc} + @{Fort-temp})" disabled><br>Total</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{Fort-misc}" type="number" name="attr_Fort-misc" value="0"><br>Misc</span>
+					<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Ref-Save}" type="roll" name="roll_NPC-Ref-Save" value="/w gm @{character_name}'s Ref save: [[1d20 + @{Ref}]]&#x00A;/w gm Save notes: @{save-notes}">Ref</button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{Ref}" type="number" name="attr_Ref" value="(@{total-Ref} + @{DEX-mod} + @{Ref-trait} + @{Ref-enhance} + @{Ref-resist} + @{Ref-misc} + @{Ref-temp})" disabled><br>Total</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{Ref-misc}" type="number" name="attr_Ref-misc" value="0"><br>Misc</span>
+					<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Will-Save}" type="roll" name="roll_NPC-Will-Save" value="/w gm @{character_name}'s Will save: [[1d20 + @{Will}]]&#x00A;/w gm Save notes: @{save-notes}">Will</button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{Will}" type="number" name="attr_Will" value="(@{total-Will} + @{WIS-mod} + @{Will-trait} + @{Will-enhance} + @{Will-resist} + @{Will-misc} + @{Will-temp})" disabled><br>Total</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{Will-misc}" type="number" name="attr_Will-misc" value="0"><br>Misc</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input type="text" title="@{save-notes}" name="attr_Save-notes" placeholder="Save Notes"><br>Save Notes</span>
+				</div>
+			</div>
+			<div class="sheet-table">
+				<div class="sheet-table-row">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input type="text" title="@{npc-defensive-abilities}" name="attr_npc-defensive-abilities" placeholder="Defensive abilities"><br>Defensive Abilities</span>
+				</div>
+				<div class="sheet-table-row">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{weaknesses}" type="text" name="attr_weaknesses" placeholder="Weaknesses"><br>Weaknesses</span>
+				</div>
+			</div>
+			<div class="sheet-table">
+				<div class="sheet-table-row">				
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{DR}" type="text" name="attr_DR" placeholder="Damage Resistances"><br>Damage Resistances</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{resistances}" type="text" name="attr_resistances" placeholder="Resistances"><br>Resistances</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{immunities}" type="text" name="attr_immunities" placeholder="Immunities"><br>Immunities</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{SR}" type="number" name="attr_SR" value="0"><br>SR</span>
+				</div>
+			</div>
+		</div>	
+	</div>
+	<div>
+		<hr/>
+		<b>OFFENSE&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{npc-offense-show}" name="attr_npc-offense-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<hr/>	
+		<div style="text-align:left;" class="sheet-sect">	
+			<div class="sheet-table">
+				<div class="sheet-table-row">
+					<span class="sheet-table-data sheet-center"><b>Speed</b><br>&nbsp;</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input style="width:100%;" title="@{speed-base}" type="number" name="attr_speed-base" value="0" step="5"><br>Base</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input style="width:100%;" title="@{speed-burrow}" type="number" name="attr_speed-burrow" value="0" step="5"><br>Burrow</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input style="width:100%;" title="@{speed-climb}" type="number" name="attr_speed-climb" value="0" step="5"><br>Climb</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input style="width:100%;" title="@{speed-fly}" type="number" name="attr_speed-fly" value="0" step="5"><br>Fly</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="speed-fly-maneuverability" type="text" name="attr_speed-fly-maneuverability" placeholder="Maneuverability"><br>Maneuverability</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input style="width:100%;" title="@{speed-swim}" type="number" name="attr_speed-swim" value="0" step="5"><br>Swim</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input style="width:100%;" title="@{speed-misc}" type="number" name="attr_speed-misc" value="0" step="5"><br>Misc</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:50%;"></span>
+				</div>
+			</div>
+			<br>
+			<div>
+				<b>Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{attacks-show}" name="attr_attacks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<div class="sheet-sect">
+					<fieldset class="repeating_weapon">  
+						<div class="sheet-table">
+							<div class="sheet-table-row">
+								<span class="sheet-table-data sheet-center" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" min="0" name="attr_enhance" title="@{repeating_weapon_X_enhance}"><br>Enhance</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="checkbox" name="attr_masterwork" title="@{repeating_weapon_X_masterwork}" value="1"><br>Mwk</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_name" title="@{repeating_weapon_X_name}" placeholder="Name"><br>Name</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_attack" title="@{repeating_weapon_X_attack}" placeholder="Attack Modifiers"><br>Attack Mods</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;">
+									<select title="@{repeating_weapon_X_attack-type}" name="attr_attack-type">
+										<option value="0" selected>None</option>
+										<option value="@{attk-melee}">Melee</option>
+										<option value="@{attk-ranged}">Ranged</option>
+									</select>
+									<br>Attack Type
+								</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_total-attack" title="@{repeating_weapon_X_total-attack}" value="(@{proficiency} + (((@{enhance} + @{masterwork}) + abs(@{enhance} - @{masterwork})) / 2) + @{attack} + @{attack-type} + @{armor-proficiency})" disabled><br>ATK</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_damage-dice-num" title="@{repeating_weapon_X_damage-dice-num}" min="0"><br>Dice</span>
+								<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;width:2%;">d</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_damage-die" title="@{repeating_weapon_X_damage-die}" min="0"><br>Die</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_damage" title="@{repeating_weapon_X_damage}" placeholder="Damage Modifiers"><br>Damage Mods</span>
+								<span class="sheet-table-data sheet-center" style="width:15%;">
+									<select title="@{repeating_weapon_X_damage-ability}" name="attr_damage-ability">
+										<option value="0" selected>None</option>
+										<option value="floor(0.5 * @{STR-mod})">1/2 STR</option>
+										<option value="floor(0.5 * @{DEX-mod})">1/2 DEX</option>
+										<option value="floor(0.5 * @{CON-mod})">1/2 CON</option>
+										<option value="floor(0.5 * @{INT-mod})">1/2 INT</option>
+										<option value="floor(0.5 * @{WIS-mod})">1/2 WIS</option>
+										<option value="floor(0.5 * @{CHA-mod})">1/2 CHA</option>
+										<option value="@{STR-mod}">STR</option>
+										<option value="@{DEX-mod}">DEX</option>
+										<option value="@{CON-mod}">CON</option>
+										<option value="@{INT-mod}">INT</option>
+										<option value="@{WIS-mod}">WIS</option>
+										<option value="@{CHA-mod}">CHA</option>
+										<option value="floor(1.5 * @{STR-mod})">1.5x STR</option>
+										<option value="floor(1.5 * @{DEX-mod})">1.5x DEX</option>
+										<option value="floor(1.5 * @{CON-mod})">1.5x CON</option>
+										<option value="floor(1.5 * @{INT-mod})">1.5x INT</option>
+										<option value="floor(1.5 * @{WIS-mod})">1.5x WIS</option>
+										<option value="floor(1.5 * @{CHA-mod})">1.5x CHA</option>
+										<option value="floor(2 * @{STR-mod})">2x STR</option>
+										<option value="floor(2 * @{DEX-mod})">2x DEX</option>
+										<option value="floor(2 * @{CON-mod})">2x CON</option>
+										<option value="floor(2 * @{INT-mod})">2x INT</option>
+										<option value="floor(2 * @{WIS-mod})">2x WIS</option>
+										<option value="floor(2 * @{CHA-mod})">2x CHA</option>
+									</select>
+									<br>Damage Ability
+								</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_total-damage" title="@{repeating_weapon_X_total-damage}" value="(@{enhance} + @{damage} + @{damage-ability})" disabled><br>DMG</span>
+							</div>
+						</div>
+						<div class="sheet-table">
+							<div class="sheet-table-row">
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_crit-target" title="@{repeating_weapon_X_crit-target}" min="0" max="20"><br>Crit</span>
+								<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;width:2%;"><b>/x</b></span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_crit-multiplier" title="@{repeating_weapon_X_crit-multiplier}" min="0"><br>Multiplier</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_range" title="@{repeating_weapon_X_range}" value="0" min="0"><br>Range</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_type" title="@{repeating_weapon_X_type}" placeholder="Damage Type"><br>Damage Type</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_weight" title="@{repeating_weapon_X_weight}" value="0" step="any" min="0"><br>Weight</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_ammo" title="@{repeating_weapon_X_ammo}" value="0"><br>Ammo</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;">
+									<select title="@{repeating_weapon_X_proficiency}" name="attr_proficiency">
+										<option value="0">Yes</option>
+										<option value="-4" selected>No</option>
+									</select>
+									<br>Proficiency
+								</span>
+								<span class="sheet-table-data sheet-center sheet-small-label" style="width:48%;"><input type="text" name="attr_notes" title="@{repeating_weapon_X_notes}" placeholder="Attack Notes"><br>Notes</span>
+							</div>
+						</div>
+						<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_weapon_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+						<textarea class="sheet-macro-text" title="@{repeating_weapon_X_macro-text}" name="attr_macro-text">/em is attacking @{target|token_name} with @{name}!&#x00A;/w gm Attack Result: [[1d20 + @{total-attack}]]&#x00A;/w gm (Needs at least [[(@{crit-target}) + @{total-attack}]] to crit.)&#x00A;/w gm Damage Result: [[@{damage-dice-num}d@{damage-die} + @{total-damage}]]&#x00A;/w gm Crit: @{crit-target}/x@{crit-multiplier}&#x00A;/w gm Crit Confirm: [[1d20 + @{total-attack}]]&#x00A;/w gm Crit Damage: +[[(@{damage-dice-num} * (@{crit-multiplier} - 1))d@{damage-die} + (@{total-damage} * (@{crit-multiplier} - 1))]]&#x00A;/w gm Type: @{type}&#x00A;/w gm Notes: @{notes}&#x00A;/w gm @{attack-notes}</textarea>
+						<hr>		
+					</fieldset>
+				</div>
+			</div>
+			<br>
+			<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{space}" type="number" name="attr_space" value="0" min="0"><br>Space (ft.)</span>
+			<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{reach}" type="number" name="attr_reach" value="0" step="5" min="0"><br>Reach (ft.)</span>
+			<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{reach-notes}" type="text" name="attr_reach-notes" placeholder="Reach notes"><br>Reach Notes</span>
+			<br>
+			<div>
+				<b>Special Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{npc-special-attacks-show}" name="attr_npc-special-attacks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea style="height:50px;" class="sheet-sect" title="@{npc-special-attacks}" name="attr_npc-special-attacks" placeholder="List all special combat actions here, in alphabetical order. Do not list feats."></textarea>
+			</div>
+			<br>
+			<div>
+				<b>Spell-Like Abilities</b> (<button style="font-size:100%;" title="NPC-Spell-Class-0-CL-Check" type="roll" name="roll_NPC-Spell-Class-0-CL-Check" value="/w gm @{character_name}'s @{spellclass-0-name} caster level check: [[1d20 + @{spellclass-0-level} + @{spellclass-0-level-misc}]]">CL</button>
+				<input title="spellclass-0-level" type="number" name="attr_spellclass-0-level" value="0">)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+				<input type="checkbox" class="sheet-sect-show" title="@{npc-spell-like-abilities-show}" name="attr_npc-spell-like-abilities-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<div class="sheet-sect">
+					<fieldset class="repeating_npc-spell-like-abilities">
+						<span class="sheet-table-data sheet-center sheet-small label" style="width:5%;"><button type="roll" value="@{macro-text}"></button><br>&nbsp;</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_npc-spell-like-abilities_X_used}" type="number" name="attr_used" value="0"><br>Uses/Day</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><input title="@{repeating_npc-spell-like-abilities_X_name}" type="text" name="attr_name" placeholder="Name"><br>Name</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:42%;"><input title="@{repeating_npc-spell-like-abilities_X_short-description}" type="text" name="attr_short-description" placeholder="Short Description"><br>Short Description</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;"><input title="@{repeating_npc-spell-like-abilities_X_duration}" type="text" name="attr_duration" placeholder="Duration"><br>Duration</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;"><input title="@{repeating_npc-spell-like-abilities_X_save}" type="text" name="attr_save" placeholder="Save"><br>Save</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:8%;">
+							<select title="@{repeating_npc-spell-like-abilities_X_sr}" name="attr_sr">
+								<option value="Yes">Yes</option>
+								<option value="No" selected>No</option>
+							</select>
+							<br>SR
+						</span>
+						<br>
+						<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_npc-spell-like-abilities_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+						<textarea class="sheet-macro-text" title="@{repeating_npc-spell-like-abilities_X_macro-text}" name="attr_macro-text">/em is casting something at @{target|token_name}!&#x00A;/w gm @{short-description} (@{save})</textarea>
+					</fieldset>
+				</div>
+			</div>
+			<br>
+			<div>
+				<b>Spells</b> (<button style="font-size:100%;" title="NPC-Spell-Class-1-CL-Check" type="roll" name="roll_NPC-Spell-Class-1-CL-Check" value="/w gm @{character_name}'s @{spellclass-1-name} caster level check: [[1d20 + @{spellclass-1-level} + @{spellclass-1-level-misc}]]">CL</button>
+				<input title="spellclass-1-level" type="number" name="attr_spellclass-1-level" value="0">)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+				<input type="checkbox" class="sheet-sect-show" title="@{npc-spells-show}" name="attr_npc-spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<div class="sheet-sect">
+					<fieldset class="repeating_npc-spells">
+						<span class="sheet-table-data sheet-center sheet-small label" style="width:5%;"><button type="roll" value="@{macro-text}"></button><br>&nbsp;</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_npc-spells_X_level}" type="number" name="attr_level" value="0"><br>Level</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_npc-spells_X_used}" type="number" name="attr_used" value="0"><br>Uses</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><input title="@{repeating_npc-spells_X_name}" type="text" name="attr_name" placeholder="Name"><br>Name</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:37%;"><input title="@{repeating_npc-spells_X_short-description}" type="text" name="attr_short-description" placeholder="Short Description"><br>Short Description</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;"><input title="@{repeating_npc-spells_X_duration}" type="text" name="attr_duration" placeholder="Duration"><br>Duration</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;"><input title="@{repeating_npc-spells_X_save}" type="text" name="attr_save" placeholder="Save"><br>Save</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:8%;">
+							<select title="@{repeating_npc-spells_X_sr}" name="attr_sr">
+								<option value="Yes">Yes</option>
+								<option value="No" selected>No</option>
+							</select>
+							<br>SR
+						</span>
+						<br>
+						<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_npc-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+						<textarea class="sheet-macro-text" title="@{repeating_npc-spells_X_macro-text}" name="attr_macro-text">/em is casting something at @{target|token_name}!&#x00A;/w gm @{short-description} (@{save})</textarea>
+					</fieldset>
+				</div>
+			</div>
+		</div>	
+	</div>
+	<div>
+		<hr/>
+		<b>TACTICS&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{npc-tactics-show}" name="attr_npc-tactics-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<hr/>
+		<div style="text-align:left;" class="sheet-sect">
+			<div>
+				<b>Before Combat&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{npc-before-combat-show}" name="attr_npc-before-combat-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-sect" title="@{npc-before-combat}" name="attr_npc-before-combat" placeholder="List any spells and/or abilities used before combat. His stats should reflect these spells."></textarea>
+			</div>
+			<div>
+			<b>During Combat&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{npc-during-combat-show}" name="attr_npc-during-combat-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-sect" title="@{npc-during-combat}" name="attr_npc-during-combat" placeholder="List all combat tactics here, including spell, feat, and magic item use."></textarea>
+			</div>
+			<div>
+				<b>Morale&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{npc-morale-show}" name="attr_npc-morale-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-sect" title="@{npc-morale}" name="attr_npc-morale" placeholder="List here under what condition the creature flees combat, if any."></textarea>
+			</div>
+			<div>
+				<b>Base Statistics&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{npc-base-statistics-show}" name="attr_npc-base-statistics-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<input class="sheet-sect" type="text" title="@{npc-base-statistics}" name="attr_npc-base-statistics" placeholder="If the creature has buffs and other effects active that modify his stats, the base stats should be quickly summarized here."/>
+			</div>
+		</div>	
+	</div>
+	<div>
+		<hr/>
+		<b>STATISTICS&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{npc-statistics-show}" name="attr_npc-statistics-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<hr/>
+		<div style="text-align:left;" class="sheet-sect">
+			<span class="sheet-table-data sheet-center"><input title="@{STR-base}" type="number" name="attr_STR-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-STR-Check}" type="roll" name="roll_NPC-STR-Check" value="/w gm @{character_name}'s STR Check: [[1d20 + @{STR-mod}]]">Str</button></span> 
+			<span class="sheet-table-data sheet-center"><input title="@{DEX-base}" type="number" name="attr_DEX-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-DEX-Check}" type="roll" name="roll_NPC-DEX-Check" value="/w gm @{character_name}'s DEX Check: [[1d20 + @{DEX-mod}]]">Dex</button></span> 
+			<span class="sheet-table-data sheet-center"><input title="@{CON-base}" type="number" name="attr_CON-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-CON-Check}" type="roll" name="roll_NPC-CON-Check" value="/w gm @{character_name}'s CON Check: [[1d20 + @{CON-mod}]]">Con</button></span> 
+			<span class="sheet-table-data sheet-center"><input title="@{INT-base}" type="number" name="attr_INT-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-INT-Check}" type="roll" name="roll_NPC-INT-Check" value="/w gm @{character_name}'s INT Check: [[1d20 + @{INT-mod}]]">Int</button></span> 
+			<span class="sheet-table-data sheet-center"><input title="@{WIS-base}" type="number" name="attr_WIS-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-WIS-Check}" type="roll" name="roll_NPC-WIS-Check" value="/w gm @{character_name}'s WIS Check: [[1d20 + @{WIS-mod}]]">Wis</button></span> 
+			<span class="sheet-table-data sheet-center"><input title="@{CHA-base}" type="number" name="attr_CHA-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-CHA-Check}" type="roll" name="roll_NPC-CHA-Check" value="/w gm @{character_name}'s CHA Check: [[1d20 + @{CHA-mod}]]">Cha</button></span> 
+			<br>
+			<div class="sheet-table">
+				<div class="sheet-table-row">
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{class-0-bab}" type="number" name="attr_class-0-bab" value="0"><br>BAB</span> 
+					<span class="sheet-table-data sheet-center" ><b>&nbsp;</b></span>
+					<span class="sheet-table-data sheet-center"><input title="@{CMB}" type="number" name="attr_CMB" value="(@{bab} + @{attk-CMB-ability} + @{attk-CMB-size} + @{attk-CMB-misc} + @{attk-CMB-temp})" disabled><br><button style="font-size:100%;" type="roll" title="NPC-CMB-Check" name="roll_NPC-CMB-Check" value="/w gm @{character_name}'s CMB check: [[1d20 + @{CMB}]]">CMB</button></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{attk-CMB-misc}" type="number" name="attr_attk-CMB-misc" value="0"><br>Misc</span>
+					<span class="sheet-table-data sheet-center" ><b>&nbsp;</b></span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{CMD}" type="number" name="attr_CMD" value="(10 + @{bab} + @{STR-mod} + @{DEX-mod} + @{CMD-size} + @{AC-dodge} + @{AC-deflect} + @{CMD-misc} + @{CMD-temp} + @{AC-penalty})" disabled><br>CMD</span>
+					<span class="sheet-table-data sheet-center sheet-small-label"><input title="@{CMD-misc}" type="number" name="attr_CMD-misc" value="0"><br>Misc</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:100%;"><input title="@{cmd-notes}" type="text" name="attr_CMD-notes" placeholder="Put notes about context-sensitive CMD bonuses here."><br>CMD Notes</span>				
+				</div>
+			</div>
+			<br>
+			<div>
+				<b>Feats&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{npc-feats-show}" name="attr_npc-feats-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<div class="sheet-table sheet-sect">
+					<fieldset class="repeating_feat">  
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button><br>&nbsp;</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:23%;"><input title="@{repeating_feat_X_name}" type="text" name="attr_name" placeholder="Feat Name"><br>Name</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:45%;"><input title="@{repeating_feat_X_short-description}" type="text" name="attr_short-description" placeholder="Short Description"><br>Short Description</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_feat_X_used}" type="number" name="attr_used" value="0"><br>Used</span>
+						<span class="sheet-table-data sheet-center" style="width:2%;vertical-align:middle;font-size:150%;">/<br>&nbsp;</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_feat_X_used|max" type="number" name="attr_used_max" value="@{max-calculation}" disabled><br>Max</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input title="@{repeating_feat_X_max-calculation}" type="text" name="attr_max-calculation" value="0"><br>Max Calculation</span>
+						<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+						<input type="checkbox" class="sheet-desc-show" title="@{repeating_feat_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+						<textarea class="sheet-desc" title="@{repeating_feat_X_description}" name="attr_description"></textarea>
+						<br>
+						<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_feat_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+						<textarea class="sheet-macro-text" title="@{repeating_feat_X_macro-text}" name="attr_macro-text">/em is activating their @{name} feat&#x00A;@{short-description}&#x00A;/w gm @{name} uses remaining: [[@{used}-1]]</textarea>
+						<hr>
+					</fieldset>
+				</div>
+			</div>
+			<br>
+				<div>
+				<b>Skills&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{npc-skills-show}" name="attr_npc-skills-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<div class="sheet-table sheet-sect">
+					<div class="sheet-table-row">
+						<span class="sheet-table-header"></span>
+						<span class="sheet-table-header">Name</span>
+						<span class="sheet-table-header">Total</span>
+						<span class="sheet-table-header">Misc</span>
+						<span class="sheet-table-header"></span>
+						<span class="sheet-table-header">Name</span>
+						<span class="sheet-table-header">Total</span>
+						<span class="sheet-table-header">Misc</span>
+						<span class="sheet-table-header"></span>
+						<span class="sheet-table-header">Name</span>
+						<span class="sheet-table-header">Total</span>
+						<span class="sheet-table-header">Misc</span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Acrobatics-Check}" type="roll" value="/w gm @{character_name}'s Acrobatics check: [[1d20 + @{Acrobatics}]]" name="roll_NPC-Acrobatics-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Acrobatics</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Acrobatics}" type="number" name="attr_Acrobatics" value="(@{Acrobatics-ranks} + @{Acrobatics-class} + @{Acrobatics-ability} + @{Acrobatics-racial} + @{Acrobatics-feat} + @{Acrobatics-item} + @{Acrobatics-acp} + @{Acrobatics-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Acrobatics-misc}" type="number" name="attr_Acrobatics-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Appraise-Check}" type="roll" value="/w gm @{character_name}'s Appraise check: [[1d20 + @{Appraise}]]" name="roll_NPC-Appraise-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Appraise</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Appraise}" type="number" name="attr_Appraise" value="(@{Appraise-ranks} + @{Appraise-class} + @{Appraise-ability} + @{Appraise-racial} + @{Appraise-feat} + @{Appraise-item} + @{Appraise-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Appraise-misc}" type="number" name="attr_Appraise-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Bluff-Check}" type="roll" value="/w gm @{character_name}'s Bluff check: [[1d20 + @{Bluff}]]" name="roll_NPC-Bluff-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Bluff</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Bluff}" type="number" name="attr_Bluff" value="(@{Bluff-ranks} + @{Bluff-class} + @{Bluff-ability} + @{Bluff-racial} + @{Bluff-feat} + @{Bluff-item} + @{Bluff-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Bluff-misc}" type="number" name="attr_Bluff-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Climb-Check}" type="roll" value="/w gm @{character_name}'s Climb check: [[1d20 + @{Climb}]]" name="roll_NPC-Climb-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Climb</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Climb}" type="number" name="attr_Climb" value="(@{Climb-ranks} + @{Climb-class} + @{Climb-ability} + @{Climb-racial} + @{Climb-feat} + @{Climb-item} + @{Climb-acp} + @{Climb-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Climb-misc}" type="number" name="attr_Climb-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Craft-Check}" type="roll" value="/w gm @{character_name}'s Craft: @{Craft-name} check: [[1d20 + @{Craft}]]" name="roll_NPC-Craft-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft-name}" style="width:50%;" type="text" name="attr_Craft-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Craft}" type="number" name="attr_Craft" value="(@{Craft-ranks} + @{Craft-class} + @{Craft-ability} + @{Craft-racial} + @{Craft-feat} + @{Craft-item} + @{Craft-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Craft-misc}" type="number" name="attr_Craft-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Craft2-Check}" type="roll" value="/w gm @{character_name}'s Craft: @{Craft2-name} check: [[1d20 + @{Craft2}]]" name="roll_NPC-Craft2-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft2-name}" style="width:50%;" type="text" name="attr_Craft2-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Craft2}" type="number" name="attr_Craft2" value="(@{Craft2-ranks} + @{Craft2-class} + @{Craft2-ability} + @{Craft2-racial} + @{Craft2-feat} + @{Craft2-item} + @{Craft2-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Craft2-misc}" type="number" name="attr_Craft2-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Craft3-Check}" type="roll" value="/w gm @{character_name}'s Craft: @{Craft3-name} check: [[1d20 + @{Craft3}]]" name="roll_NPC-Craft3-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft3-name}" style="width:50%;" type="text" name="attr_Craft3-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Craft3}" type="number" name="attr_Craft3" value="(@{Craft3-ranks} + @{Craft3-class} + @{Craft3-ability} + @{Craft3-racial} + @{Craft3-feat} + @{Craft3-item} + @{Craft3-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Craft3-misc}" type="number" name="attr_Craft3-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Diplomacy-Check}" type="roll" value="/w gm @{character_name}'s Diplomacy check: [[1d20 + @{Diplomacy}]]" name="roll_NPC-Diplomacy-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Diplomacy</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Diplomacy}" type="number" name="attr_Diplomacy" value="(@{Diplomacy-ranks} + @{Diplomacy-class} + @{Diplomacy-ability} + @{Diplomacy-racial} + @{Diplomacy-feat} + @{Diplomacy-item} + @{Diplomacy-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Diplomacy-misc}" type="number" name="attr_Diplomacy-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Disable-Device-Check}" type="roll" value="/w gm @{character_name}'s Disable Device check: [[1d20 + @{Disable-Device}]]" name="roll_NPC-Disable-Device-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Disable Device</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Disable-Device}" type="number" name="attr_Disable-Device" value="(@{Disable-Device-ranks} + @{Disable-Device-class} + @{Disable-Device-ability} + @{Disable-Device-racial} + @{Disable-Device-feat} + @{Disable-Device-item} + @{Disable-Device-acp} + @{Disable-Device-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-misc}" type="number" name="attr_Disable-Device-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Disguise-Check}" type="roll" value="/w gm @{character_name}'s Disguise check: [[1d20 + @{Disguise}]]" name="roll_NPC-Disguise-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Disguise</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Disguise}" type="number" name="attr_Disguise" value="(@{Disguise-ranks} + @{Disguise-class} + @{Disguise-ability} + @{Disguise-racial} + @{Disguise-feat} + @{Disguise-item} + @{Disguise-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Disguise-misc}" type="number" name="attr_Disguise-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Escape-Artist-Check}" type="roll" value="/w gm @{character_name}'s Escape Artist check: [[1d20 + @{Escape-Artist}]]" name="roll_NPC-Escape-Artist-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Escape Artist</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist}" type="number" name="attr_Escape-Artist" value="(@{Escape-Artist-ranks} + @{Escape-Artist-class} + @{Escape-Artist-ability} + @{Escape-Artist-racial} + @{Escape-Artist-feat} + @{Escape-Artist-item} + @{Escape-Artist-acp} + @{Escape-Artist-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-misc}" type="number" name="attr_Escape-Artist-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Fly-Check}" type="roll" value="/w gm @{character_name}'s Fly check: [[1d20 + @{Fly}]]" name="roll_NPC-Fly-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Fly</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Fly}" type="number" name="attr_Fly" value="(@{Fly-ranks} + @{Fly-class} + @{Fly-ability} + @{Fly-racial} + @{Fly-feat} + @{Fly-item} + @{Fly-acp} + @{Fly-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Fly-misc}" type="number" name="attr_Fly-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Handle-Animal-Check}" type="roll" value="/w gm @{character_name}'s Handle Animal check: [[1d20 + @{Handle-Animal}]]" name="roll_NPC-Handle-Animal-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Handle Animal</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal}" type="number" name="attr_Handle-Animal" value="(@{Handle-Animal-ranks} + @{Handle-Animal-class} + @{Handle-Animal-ability} + @{Handle-Animal-racial} + @{Handle-Animal-feat} + @{Handle-Animal-item} + @{Handle-Animal-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-misc}" type="number" name="attr_Handle-Animal-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Heal-Check}" type="roll" value="/w gm @{character_name}'s Heal check: [[1d20 + @{Heal}]]" name="roll_NPC-Heal-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Heal</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Heal}" type="number" name="attr_Heal" value="(@{Heal-ranks} + @{Heal-class} + @{Heal-ability} + @{Heal-racial} + @{Heal-feat} + @{Heal-item} + @{Heal-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Heal-misc}" type="number" name="attr_Heal-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Intimidate-Check}" type="roll" value="/w gm @{character_name}'s Intimidate check: [[1d20 + @{Intimidate}]]" name="roll_NPC-Intimidate-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Intimidate</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Intimidate}" type="number" name="attr_Intimidate" value="(@{Intimidate-ranks} + @{Intimidate-class} + @{Intimidate-ability} + @{Intimidate-racial} + @{Intimidate-feat} + @{Intimidate-item} + @{Intimidate-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Intimidate-misc}" type="number" name="attr_Intimidate-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Arcana-Check}" type="roll" value="/w gm @{character_name}'s Knowledge (Arcana) check: [[1d20 + @{Knowledge-Arcana}]]" name="roll_NPC-Knowledge-Arcana-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Knowledge (Arcana)</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana}" type="number" name="attr_Knowledge-Arcana" value="(@{Knowledge-Arcana-ranks} + @{Knowledge-Arcana-class} + @{Knowledge-Arcana-ability} + @{Knowledge-Arcana-racial} + @{Knowledge-Arcana-feat} + @{Knowledge-Arcana-item} + @{Knowledge-Arcana-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-misc}" type="number" name="attr_Knowledge-Arcana-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Dungeoneering-Check}" type="roll" value="/w gm @{character_name}'s Knowledge (Dungeoneering) check: [[1d20 + @{Knowledge-Dungeoneering}]]" name="roll_NPC-Knowledge-Dungeoneering-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Knowledge (Dungeoneering)</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering}" type="number" name="attr_Knowledge-Dungeoneering" value="(@{Knowledge-Dungeoneering-ranks} + @{Knowledge-Dungeoneering-class} + @{Knowledge-Dungeoneering-ability} + @{Knowledge-Dungeoneering-racial} + @{Knowledge-Dungeoneering-feat} + @{Knowledge-Dungeoneering-item} + @{Knowledge-Dungeoneering-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-misc}" type="number" name="attr_Knowledge-Dungeoneering-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Engineering-Check}" type="roll" value="/w gm @{character_name}'s Knowledge (Engineering) check: [[1d20 + @{Knowledge-Engineering}]]" name="roll_NPC-Knowledge-Engineering-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Knowledge (Engineering)</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering}" type="number" name="attr_Knowledge-Engineering" value="(@{Knowledge-Engineering-ranks} + @{Knowledge-Engineering-class} + @{Knowledge-Engineering-ability} + @{Knowledge-Engineering-racial} + @{Knowledge-Engineering-feat} + @{Knowledge-Engineering-item} + @{Knowledge-Engineering-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-misc}" type="number" name="attr_Knowledge-Engineering-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Geography-Check}" type="roll" value="/w gm @{character_name}'s Knowledge (Geography) check: [[1d20 + @{Knowledge-Geography}]]" name="roll_NPC-Knowledge-Geography-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Knowledge (Geography)</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography}" type="number" name="attr_Knowledge-Geography" value="(@{Knowledge-Geography-ranks} + @{Knowledge-Geography-class} + @{Knowledge-Geography-ability} + @{Knowledge-Geography-racial} + @{Knowledge-Geography-feat} + @{Knowledge-Geography-item} + @{Knowledge-Geography-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-misc}" type="number" name="attr_Knowledge-Geography-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-History-Check}" type="roll" value="/w gm @{character_name}'s Knowledge (History) check: [[1d20 + @{Knowledge-History}]]" name="roll_NPC-Knowledge-History-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Knowledge (History)</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History}" type="number" name="attr_Knowledge-History" value="(@{Knowledge-History-ranks} + @{Knowledge-History-class} + @{Knowledge-History-ability} + @{Knowledge-History-racial} + @{Knowledge-History-feat} + @{Knowledge-History-item} + @{Knowledge-History-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-misc}" type="number" name="attr_Knowledge-History-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Local-Check}" type="roll" value="/w gm @{character_name}'s Knowledge (Local) check: [[1d20 + @{Knowledge-Local}]]" name="roll_NPC-Knowledge-Local-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Knowledge (Local)</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local}" type="number" name="attr_Knowledge-Local" value="(@{Knowledge-Local-ranks} + @{Knowledge-Local-class} + @{Knowledge-Local-ability} + @{Knowledge-Local-racial} + @{Knowledge-Local-feat} + @{Knowledge-Local-item} + @{Knowledge-Local-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-misc}" type="number" name="attr_Knowledge-Local-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Nature-Check}" type="roll" value="/w gm @{character_name}'s Knowledge (Nature) check: [[1d20 + @{Knowledge-Nature}]]" name="roll_NPC-Knowledge-Nature-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Knowledge (Nature)</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature}" type="number" name="attr_Knowledge-Nature" value="(@{Knowledge-Nature-ranks} + @{Knowledge-Nature-class} + @{Knowledge-Nature-ability} + @{Knowledge-Nature-racial} + @{Knowledge-Nature-feat} + @{Knowledge-Nature-item} + @{Knowledge-Nature-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-misc}" type="number" name="attr_Knowledge-Nature-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Nobility-Check}" type="roll" value="/w gm @{character_name}'s Knowledge (Nobility) check: [[1d20 + @{Knowledge-Nobility}]]" name="roll_NPC-Knowledge-Nobility-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Knowledge (Nobility)</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility}" type="number" name="attr_Knowledge-Nobility" value="(@{Knowledge-Nobility-ranks} + @{Knowledge-Nobility-class} + @{Knowledge-Nobility-ability} + @{Knowledge-Nobility-racial} + @{Knowledge-Nobility-feat} + @{Knowledge-Nobility-item} + @{Knowledge-Nobility-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-misc}" type="number" name="attr_Knowledge-Nobility-misc" value="0"></span>
+	
+
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Planes-Check}" type="roll" value="/w gm @{character_name}'s Knowledge (Planes) check: [[1d20 + @{Knowledge-Planes}]]" name="roll_NPC-Knowledge-Planes-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Knowledge (Planes)</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes}" type="number" name="attr_Knowledge-Planes" value="(@{Knowledge-Planes-ranks} + @{Knowledge-Planes-class} + @{Knowledge-Planes-ability} + @{Knowledge-Planes-racial} + @{Knowledge-Planes-feat} + @{Knowledge-Planes-item} + @{Knowledge-Planes-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-misc}" type="number" name="attr_Knowledge-Planes-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Religion-Check}" type="roll" value="/w gm @{character_name}'s Knowledge (Religion) check: [[1d20 + @{Knowledge-Religion}]]" name="roll_NPC-Knowledge-Religion-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Knowledge (Religion)</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion}" type="number" name="attr_Knowledge-Religion" value="(@{Knowledge-Religion-ranks} + @{Knowledge-Religion-class} + @{Knowledge-Religion-ability} + @{Knowledge-Religion-racial} + @{Knowledge-Religion-feat} + @{Knowledge-Religion-item} + @{Knowledge-Religion-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-misc}" type="number" name="attr_Knowledge-Religion-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Linguistics-Check}" type="roll" value="/w gm @{character_name}'s Linguistics check: [[1d20 + @{Linguistics}]]" name="roll_NPC-Linguistics-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Linguistics</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Linguistics}" type="number" name="attr_Linguistics" value="(@{Linguistics-ranks} + @{Linguistics-class} + @{Linguistics-ability} + @{Linguistics-racial} + @{Linguistics-feat} + @{Linguistics-item} + @{Linguistics-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Linguistics-misc}" type="number" name="attr_Linguistics-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Perception-Check}" type="roll" value="/w gm @{character_name}'s Perception check: [[1d20 + @{Perception}]]" name="roll_NPC-Perception-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Perception</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Perception}" type="number" name="attr_Perception" value="(@{Perception-ranks} + @{Perception-class} + @{Perception-ability} + @{Perception-racial} + @{Perception-feat} + @{Perception-item} + @{Perception-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Perception-misc}" type="number" name="attr_Perception-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Perform-Check}" type="roll" value="/w gm @{character_name}'s Perform: @{Perform-name} check: [[1d20 + @{Perform}]]" name="roll_NPC-Perform-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform-name}" style="width:50%;" type="text" name="attr_Perform-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Perform}" type="number" name="attr_Perform" value="(@{Perform-ranks} + @{Perform-class} + @{Perform-ability} + @{Perform-racial} + @{Perform-feat} + @{Perform-item} + @{Perform-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Perform-misc}" type="number" name="attr_Perform-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Perform2-Check}" type="roll" value="/w gm @{character_name}'s Perform: @{Perform2-name} check: [[1d20 + @{Perform2}]]" name="roll_NPC-Perform2-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform2-name}" style="width:50%;" type="text" name="attr_Perform2-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Perform2}" type="number" name="attr_Perform2" value="(@{Perform2-ranks} + @{Perform2-class} + @{Perform2-ability} + @{Perform2-racial} + @{Perform2-feat} + @{Perform2-item} + @{Perform2-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Perform2-misc}" type="number" name="attr_Perform2-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Perform3-Check}" type="roll" value="/w gm @{character_name}'s Perform: @{Perform3-name} check: [[1d20 + @{Perform3}]]" name="roll_NPC-Perform3-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform3-name}" style="width:50%;" type="text" name="attr_Perform3-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Perform3}" type="number" name="attr_Perform3" value="(@{Perform3-ranks} + @{Perform3-class} + @{Perform3-ability} + @{Perform3-racial} + @{Perform3-feat} + @{Perform3-item} + @{Perform3-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Perform3-misc}" type="number" name="attr_Perform3-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Profession-Check}" type="roll" value="/w gm @{character_name}'s Profession: @{Profession-name} check: [[1d20 + @{Profession}]]" name="roll_NPC-Profession-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession-name}" style="width:50%;" type="text" name="attr_Profession-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Profession}" type="number" name="attr_Profession" value="(@{Profession-ranks} + @{Profession-class} + @{Profession-ability} + @{Profession-racial} + @{Profession-feat} + @{Profession-item} + @{Profession-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Profession-misc}" type="number" name="attr_Profession-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Profession2-Check}" type="roll" value="/w gm @{character_name}'s Profession: @{Profession2-name} check: [[1d20 + @{Profession2}]]" name="roll_NPC-Profession2-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession2-name}" style="width:50%;" type="text" name="attr_Profession2-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Profession2}" type="number" name="attr_Profession2" value="(@{Profession2-ranks} + @{Profession2-class} + @{Profession2-ability} + @{Profession2-racial} + @{Profession2-feat} + @{Profession2-item} + @{Profession2-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Profession2-misc}" type="number" name="attr_Profession2-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Profession3-Check}" type="roll" value="/w gm @{character_name}'s Profession: @{Profession3-name} check: [[1d20 + @{Profession3}]]" name="roll_NPC-Profession3-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession3-name}" style="width:50%;" type="text" name="attr_Profession3-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Profession3}" type="number" name="attr_Profession3" value="(@{Profession3-ranks} + @{Profession3-class} + @{Profession3-ability} + @{Profession3-racial} + @{Profession3-feat} + @{Profession3-item} + @{Profession3-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Profession3-misc}" type="number" name="attr_Profession3-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Ride-Check}" type="roll" value="/w gm @{character_name}'s Ride check: [[1d20 + @{Ride}]]" name="roll_NPC-Ride-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Ride</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Ride}" type="number" name="attr_Ride" value="(@{Ride-ranks} + @{Ride-class} + @{Ride-ability} + @{Ride-racial} + @{Ride-feat} + @{Ride-item} + @{Ride-acp} + @{Ride-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Ride-misc}" type="number" name="attr_Ride-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Sense-Motive-Check}" type="roll" value="/w gm @{character_name}'s Sense Motive check: [[1d20 + @{Sense-Motive}]]" name="roll_NPC-Sense-Motive-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Sense Motive</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive}" type="number" name="attr_Sense-Motive" value="(@{Sense-Motive-ranks} + @{Sense-Motive-class} + @{Sense-Motive-ability} + @{Sense-Motive-racial} + @{Sense-Motive-feat} + @{Sense-Motive-item} + @{Sense-Motive-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-misc}" type="number" name="attr_Sense-Motive-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Sleight-of-Hand-Check}" type="roll" value="/w gm @{character_name}'s Sleight of Hand check: [[1d20 + @{Sleight-of-Hand}]]" name="roll_NPC-Sleight-of-Hand-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Sleight of Hand</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand}" type="number" name="attr_Sleight-of-Hand" value="(@{Sleight-of-Hand-ranks} + @{Sleight-of-Hand-class} + @{Sleight-of-Hand-ability} + @{Sleight-of-Hand-racial} + @{Sleight-of-Hand-feat} + @{Sleight-of-Hand-item} + @{Sleight-of-Hand-acp} + @{Sleight-of-Hand-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-misc}" type="number" name="attr_Sleight-of-Hand-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Spellcraft-Check}" type="roll" value="/w gm @{character_name}'s Spellcraft check: [[1d20 + @{Spellcraft}]]" name="roll_NPC-Spellcraft-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Spellcraft</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Spellcraft}" type="number" name="attr_Spellcraft" value="(@{Spellcraft-ranks} + @{Spellcraft-class} + @{Spellcraft-ability} + @{Spellcraft-racial} + @{Spellcraft-feat} + @{Spellcraft-item} + @{Spellcraft-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Spellcraft-misc}" type="number" name="attr_Spellcraft-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Stealth-Check}" type="roll" value="/w gm @{character_name}'s Stealth check: [[1d20 + @{Stealth}]]" name="roll_NPC-Stealth-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Stealth</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Stealth}" type="number" name="attr_Stealth" value="(@{Stealth-ranks} + @{Stealth-class} + @{Stealth-ability} + @{Stealth-racial} + @{Stealth-feat} + @{Stealth-item} + @{Stealth-acp} + @{Stealth-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Stealth-misc}" type="number" name="attr_Stealth-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Survival-Check}" type="roll" value="/w gm @{character_name}'s Survival check: [[1d20 + @{Survival}]]" name="roll_NPC-Survival-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Survival</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Survival}" type="number" name="attr_Survival" value="(@{Survival-ranks} + @{Survival-class} + @{Survival-ability} + @{Survival-racial} + @{Survival-feat} + @{Survival-item} + @{Survival-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Survival-misc}" type="number" name="attr_Survival-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Swim-Check}" type="roll" value="/w gm @{character_name}'s Swim check: [[1d20 + @{Swim}]]" name="roll_NPC-Swim-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Swim</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Swim}" type="number" name="attr_Swim" value="(@{Swim-ranks} + @{Swim-class} + @{Swim-ability} + @{Swim-racial} + @{Swim-feat} + @{Swim-item} + @{Swim-acp} + @{Swim-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Swim-misc}" type="number" name="attr_Swim-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Use-Magic-Device-Check}" type="roll" value="/w gm @{character_name}'s Use Magic Device check: [[1d20 + @{Use-Magic-Device}]]" name="roll_NPC-Use-Magic-Device-Check"></button></span>
+						<span class="sheet-table-data sheet-left">Use Magic Device</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device}" type="number" name="attr_Use-Magic-Device" value="(@{Use-Magic-Device-ranks} + @{Use-Magic-Device-class} + @{Use-Magic-Device-ability} + @{Use-Magic-Device-racial} + @{Use-Magic-Device-feat} + @{Use-Magic-Device-item} + @{Use-Magic-Device-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-misc}" type="number" name="attr_Use-Magic-Device-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-0-Check}" type="roll" value="/w gm @{character_name}'s @{Misc-Skill-0-name} check: [[1d20 + @{Misc-Skill-0}]]" name="roll_NPC-Misc-Skill-0-Check"></button></span>
+						<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-0-name}" name="attr_Misc-Skill-0-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0}" type="number" name="attr_Misc-Skill-0" value="(@{Misc-Skill-0-ranks} + @{Misc-Skill-0-class} + @{Misc-Skill-0-ability} + @{Misc-Skill-0-racial} + @{Misc-Skill-0-feat} + @{Misc-Skill-0-item} + @{Misc-Skill-0-acp} + @{Misc-Skill-0-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-misc}" type="number" name="attr_Misc-Skill-0-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-1-Check}" type="roll" value="/w gm @{character_name}'s @{Misc-Skill-1-name} check: [[1d20 + @{Misc-Skill-1}]]" name="roll_NPC-Misc-Skill-1-Check"></button></span>
+						<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-1-name}" name="attr_Misc-Skill-1-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1}" type="number" name="attr_Misc-Skill-1" value="(@{Misc-Skill-1-ranks} + @{Misc-Skill-1-class} + @{Misc-Skill-1-ability} + @{Misc-Skill-1-racial} + @{Misc-Skill-1-feat} + @{Misc-Skill-1-item} + @{Misc-Skill-1-acp} + @{Misc-Skill-1-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-misc}" type="number" name="attr_Misc-Skill-1-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-2-Check}" type="roll" value="/w gm @{character_name}'s @{Misc-Skill-2-name} check: [[1d20 + @{Misc-Skill-2}]]" name="roll_NPC-Misc-Skill-2-Check"></button></span>
+						<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-2-name}" name="attr_Misc-Skill-2-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2}" type="number" name="attr_Misc-Skill-2" value="(@{Misc-Skill-2-ranks} + @{Misc-Skill-2-class} + @{Misc-Skill-2-ability} + @{Misc-Skill-2-racial} + @{Misc-Skill-2-feat} + @{Misc-Skill-2-item} + @{Misc-Skill-2-acp} + @{Misc-Skill-2-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-misc}" type="number" name="attr_Misc-Skill-2-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-3-Check}" type="roll" value="/w gm @{character_name}'s @{Misc-Skill-3-name} check: [[1d20 + @{Misc-Skill-3}]]" name="roll_NPC-Misc-Skill-3-Check"></button></span>
+						<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-3-name}" name="attr_Misc-Skill-3-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3}" type="number" name="attr_Misc-Skill-3" value="(@{Misc-Skill-3-ranks} + @{Misc-Skill-3-class} + @{Misc-Skill-3-ability} + @{Misc-Skill-3-racial} + @{Misc-Skill-3-feat} + @{Misc-Skill-3-item} + @{Misc-Skill-3-acp} + @{Misc-Skill-3-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-misc}" type="number" name="attr_Misc-Skill-3-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-4-Check}" type="roll" value="/w gm @{character_name}'s @{Misc-Skill-4-name} check: [[1d20 + @{Misc-Skill-4}]]" name="roll_NPC-Misc-Skill-4-Check"></button></span>
+						<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-4-name}" name="attr_Misc-Skill-4-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4}" type="number" name="attr_Misc-Skill-4" value="(@{Misc-Skill-4-ranks} + @{Misc-Skill-4-class} + @{Misc-Skill-4-ability} + @{Misc-Skill-4-racial} + @{Misc-Skill-4-feat} + @{Misc-Skill-4-item} + @{Misc-Skill-4-acp} + @{Misc-Skill-4-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-misc}" type="number" name="attr_Misc-Skill-4-misc" value="0"></span>
+	
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-5-Check}" type="roll" value="/w gm @{character_name}'s @{Misc-Skill-5-name} check: [[1d20 + @{Misc-Skill-5}]]" name="roll_NPC-Misc-Skill-5-Check"></button></span>
+						<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-5-name}" name="attr_Misc-Skill-5-name"></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5}" type="number" name="attr_Misc-Skill-5" value="(@{Misc-Skill-5-ranks} + @{Misc-Skill-5-class} + @{Misc-Skill-5-ability} + @{Misc-Skill-5-racial} + @{Misc-Skill-5-feat} + @{Misc-Skill-5-item} + @{Misc-Skill-5-acp} + @{Misc-Skill-5-misc})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-misc}" type="number" name="attr_Misc-Skill-5-misc" value="0"></span>
+					</div>
+				</div>	
+			</div>
+			<br>
+			<div class="sheet-table">
+				<div class="sheet-table-row">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:95%;"><input type="text" title="@{languages}" name="attr_languages" placeholder="Languages"><br>Languages</span>
+				</div>
+			</div>
+			<br>
+			<div class="sheet-table">
+				<div class="sheet-table-row">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:95%;"><input type="text" title="@{SQ}" name="attr_SQ" placeholder="Add all special qualities here, listed alphabetically"><br>SQ</span>
+				</div>
+			</div>
+			<br>
+			<div class="sheet-table">
+				<b>Combat Gear&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{npc-cgear-show}" name="attr_npc-cgear-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<div class="sheet-table-row sheet-sect">
+					<span class="sheet-table-data sheet-center"><textarea title="@{npc-combat-gear}" name="attr_npc-combat-gear" style="height:50px;width:97%;" placeholder="Gear used in combat"></textarea></span>	
+				</div>			
+			</div> 
+			<br>
+			<div class="sheet-table">
+				<b>Other Gear&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{npc-ogear-show}" name="attr_npc-ogear-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<div class="sheet-table-row sheet-sect">
+					<span class="sheet-table-data sheet-center"><textarea title="@{npc-other-gear}" name="attr_npc-other-gear" style="height:50px;width:97%;" placeholder="Gear not used in combat"></textarea></span>
+				</div>
+			</div> 
+		</div>	
+	</div>
+	<div>
+		<hr/>
+		<b>SPECIAL ABILITIES&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{npc-special-abilities-show}" name="attr_npc-special-abilities-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<hr/>
+		<div class="sheet-table sheet-sect">
+			<fieldset class="repeating_racial-trait">
+				<div class="sheet-table-row">
+					<span class="sheet-table-data sheet-center" style="width:5%;"><button type="roll" value="@{macro-text}"></button><br>&nbsp;</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input title="@{repeating_racial-trait_X_name}" type="text" name="attr_name" placeholder="Special Ability Name"><br>Name</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:28%;"><input title="@{repeating_racial-trait_X_short-description}" type="text" name="attr_short-description" placeholder="Short Description"><br>Short Description</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_racial-trait_X_used}" type="number" name="attr_used" value="0"><br>Uses</span>
+					<span class="sheet-table-data sheet-center" style="width:2%;vertical-align:middle;font-size:150%;">/<br>/</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_racial-trait_X_used|max" type="number" name="attr_used_max" value="@{max-calculation}" disabled><br>Max</span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input title="@{repeating_racial-trait_X_max-calculation}" type="text" name="attr_max-calculation" value="0"><br>Max Calculation</span>
+				</div>
+				<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-desc-show" title="@{repeating_racial-trait_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+				<textarea class="sheet-desc" title="@{repeating_racial-trait_X_description}" name="attr_description"></textarea>
+				<br>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_racial-trait_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_racial-trait_X_macro-text}" name="attr_macro-text">/em is activating a special ability!&#x00A;/w gm @{short-description}&#x00A;/w gm @{name} uses remaining: [[@{used}-1]]</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+</div>
+<div style="text-align:center;">
+Sheet created by Samuel Marino for Roll20.net | Last updated: <i>9/23/14</i>
+<br>
+Have questions or feedback? <a href="https://app.roll20.net/forum/post/1047051/pathfinder-sheet-thread-2-golarion-boogaloo" target="_blank">This thread can help: https://app.roll20.net/forum/post/1047051/pathfinder-sheet-thread-2-golarion-boogaloo</a>
+</div>
+
+<!-- Roll Templates -->
+<rolltemplate class="sheet-rolltemplate-pf_spell">
+    <table>
+        <tr><th>{{name}}</th></tr>
+        <tr>
+            <td><span class="tcat">School </span>{{school}}; <span class="tcat">Level </span>{{level}}</td>        
+        </tr>
+        <tr>
+            <td><span class="tcat">Casting Time </span>{{casting_time}}</td>        
+        </tr>
+        <tr>
+            <td><span class="tcat">Components </span>{{components}}</td>        
+        </tr>
+        <tr>
+            <td><span class="tcat">Range </span>{{range}}</td>        
+        </tr>
+        <tr>
+            <td><span class="tcat">Effect/Target </span>{{target}}</td>        
+        </tr>
+        <tr>
+            <td><span class="tcat">Duration </span>{{duration}}</td>        
+        </tr>
+        <tr>
+            <td><span class="tcat">Saving Throw </span>{{saving_throw}} <span class="tcat">DC</span>{{dc}}</td>         
+        </tr>
+        <tr>
+            <td><span class="tcat">Spell Resistance </span>{{sr}}</td>        
+        </tr>
+        <tr>
+            {{#rng_attack}}<td><span class="tcat">Ranged Attack </span>{{rng_attack}}</td>{{/rng_attack}}
+        </tr>
+        
+        <tr>
+            {{#mel_attack}}<td><span class="tcat">Melee Attack </span>{{mel_attack}}</td>{{/mel_attack}}
+        </tr>
+        	
+		<tr>
+            {{#damage}}<td><span class="tcat">Damage: </span>{{damage}}</td>{{/damage}}
+        </tr>
+		<tr>
+            <td>{{spell_description}}</td>        
+        </tr>
+    </table>
+  </rolltemplate>
+  
+  <rolltemplate class="sheet-rolltemplate-pf_check">
+  	<table>
+    	<tr><th>{{name}}</th></tr>
+    	<tr>
+            {{#caster_class}}<td><span class="tcat">Caster's Class/Lvl: </span>{{caster_class}}</td>{{/caster_class}}
+        </tr>
+        <tr>
+            {{#caster_lvl_chk}}<td><span class="tcat">Caster Level Check: </span>{{caster_lvl_chk}}</td>{{/caster_lvl_chk}}
+        </tr>
+        <tr>
+            {{#concentration_chk}}<td><span class="tcat">Concentration Check: </span>{{concentration_chk}}</td>{{/concentration_chk}}
+        </tr>
+    </table>
+  </rolltemplate>


### PR DESCRIPTION
- added roll templates for the spells tab/section (all spell button rows and macro text)
-  added DC-mod field to repeatable spells. (repeatable DC-mod + spellclass-0-level-X-savedc) total is shown as part of the spell-block in chat DC-mod only pulls from spellclass-0 like the current sheet.  Not sure if it's worthwhile to create a solution that also works with spellclass-1
- added roll templates to Caster level checks and concentration sheet rolls

![pf_spell roll templates dc-mod](https://cloud.githubusercontent.com/assets/10321187/5796354/558e311e-9f5b-11e4-9be5-1965234b16c4.JPG)

![pf_spell roll templates](https://cloud.githubusercontent.com/assets/10321187/5796321/c0f7c9e8-9f5a-11e4-8aa9-cf2e11a52396.JPG)

![pf_check roll templates](https://cloud.githubusercontent.com/assets/10321187/5796363/683fa694-9f5b-11e4-98a4-502d32996b80.JPG)
