### PR TITLE
Roll template update pf_spell

### DIFF
--- a/Pathfinder-Neceros-roll-template/pathfinder-neceros-roll-template.html
+++ b/Pathfinder-Neceros-roll-template/pathfinder-neceros-roll-template.html
@@ -5629,60 +5629,36 @@ Have questions or feedback? <a href="https://app.roll20.net/forum/post/1047051/p
 
 <!-- Roll Templates -->
 <rolltemplate class="sheet-rolltemplate-pf_spell">
-    <table>
-        <tr><th>{{name}}</th></tr>
-        <tr>
-            <td><span class="tcat">School </span>{{school}}; <span class="tcat">Level </span>{{level}}</td>        
-        </tr>
-        <tr>
-            <td><span class="tcat">Casting Time </span>{{casting_time}}</td>        
-        </tr>
-        <tr>
-            <td><span class="tcat">Components </span>{{components}}</td>        
-        </tr>
-        <tr>
-            <td><span class="tcat">Range </span>{{range}}</td>        
-        </tr>
-        <tr>
-            <td><span class="tcat">Effect/Target </span>{{target}}</td>        
-        </tr>
-        <tr>
-            <td><span class="tcat">Duration </span>{{duration}}</td>        
-        </tr>
-        <tr>
-            <td><span class="tcat">Saving Throw </span>{{saving_throw}} <span class="tcat">DC</span>{{dc}}</td>         
-        </tr>
-        <tr>
-            <td><span class="tcat">Spell Resistance </span>{{sr}}</td>        
-        </tr>
-        <tr>
-            {{#rng_attack}}<td><span class="tcat">Ranged Attack </span>{{rng_attack}}</td>{{/rng_attack}}
-        </tr>
-        
-        <tr>
-            {{#mel_attack}}<td><span class="tcat">Melee Attack </span>{{mel_attack}}</td>{{/mel_attack}}
-        </tr>
-        	
-		<tr>
-            {{#damage}}<td><span class="tcat">Damage: </span>{{damage}}</td>{{/damage}}
-        </tr>
-		<tr>
-            <td>{{spell_description}}</td>        
-        </tr>
-    </table>
-  </rolltemplate>
-  
-  <rolltemplate class="sheet-rolltemplate-pf_check">
-  	<table>
-    	<tr><th>{{name}}</th></tr>
-    	<tr>
-            {{#caster_class}}<td><span class="tcat">Caster's Class/Lvl: </span>{{caster_class}}</td>{{/caster_class}}
-        </tr>
-        <tr>
-            {{#caster_lvl_chk}}<td><span class="tcat">Caster Level Check: </span>{{caster_lvl_chk}}</td>{{/caster_lvl_chk}}
-        </tr>
-        <tr>
-            {{#concentration_chk}}<td><span class="tcat">Concentration Check: </span>{{concentration_chk}}</td>{{/concentration_chk}}
-        </tr>
-    </table>
-  </rolltemplate>
+  <table>
+    <caption>{{name}}</caption>
+    <tr><td><span class="sheet-tcat">School</span> {{school}}<span class="tcat">; Level</span> {{level}}</td></tr>
+    <tr><td><span class="sheet-tcat">Casting Time</span> {{casting_time}}</td></tr>
+    <tr><td><span class="sheet-tcat">Components</span> {{components}}</td></tr>
+    <tr><td><span class="sheet-tcat">Range</span> {{range}}</td></tr>
+    <tr><td><span class="sheet-tcat">Effects/Target</span> {{target}}</td></tr>
+    <tr><td><span class="sheet-tcat">Duration</span> {{duration}}</td></tr>
+    <tr><td><span class="sheet-tcat">Saving Throw</span> {{saving_throw}}</td></tr>
+    <tr><td><span class="sheet-tcat">Spell Resistance</span> {{sr}}</td></tr>
+    {{#rng_attack}}
+    <tr><td><span class="sheet-tcat">Ranged Attack</span> {{rng_attack}}</td></tr>{{/rng_attack}}
+    {{#mel_attack}}
+    <tr><td><span class="sheet-tcat">Melee Attack</span> {{mel_attack}}</td></tr>{{/mel_attack}}
+    {{#damage}}
+    <tr><td><span class="sheet-tcat">Damage</span> {{damage}}</td></tr>{{/damage}}
+    <tr><td>{{spell_description}}</td></tr>
+  </table>
+
+</rolltemplate>
+
+<rolltemplate class="sheet-rolltemplate-pf_check">
+
+  <table>
+    <caption><span class="sheet-margin-header">{{name}}</span></caption>
+    <tr><td><span class="sheet-tcat">Caster's Class/Lvl:</span> {{caster_class}}</td></tr>
+    {{#caster_lvl_chk}}
+    <tr><td><span class="sheet-tcat">Caster Level Check:</span> {{caster_lvl_chk}}</td></tr>{{/caster_lvl_chk}}
+    {{#concentration_chk}}
+    <tr><td><span class="sheet-tcat">Concentration Check:</span> {{concentration_chk}}</td></tr>{{/concentration_chk}}
+  </table>
+
+</rolltemplate>


### PR DESCRIPTION
updated roll template back to a table with banding.

fixed a possible issue where the "checks" roll template title and image would fail to keep it's design if there was extended multi-line text sent into the header. This won't/wouldn't happen with our text used in the sheets roll buttons, but I could see that someone might customize a macro outside the sheet. Handles the extra text now, just incase.
